### PR TITLE
HTTPS를 위한 SSL 인증서 정보 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**/build/
 
 application-*.yml
+*.p12
 
 ### macOS ###
 .DS_Store

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,14 @@ spring:
   profiles:
     include: jasypt
 
+server:
+  port: 443
+  ssl:
+    key-store: ENC(CceBs5V+bc8OAFUqT941Rpl1zIKGGnQS)
+    key-store-password: ENC(7jjoVfr17tjpK2sFkSoE5DJL2bst58+A)
+    key-store-type: ENC(/a8N3/iKX6zawiBT/n1AjQ==)
+    key-alias: ENC(BPQBUsjoKG1RMNDe17HgxQ==)
+
 redis:
   host: ENC(7JDCGfEQHCzum4KkZl2gJc5MpHtRvoCj)
   port: ENC(yvWbrMM7Nud8Qt5S4OmQMg==)


### PR DESCRIPTION
# 관련 이슈

- #19 

# 구현 사항

- let's encrypt로 SSL 인증서를 발급
- SSL 인증서 정보 application.yml에 추가

# 참고 이미지

http로 접근하면 아래와 같이 에러가 발생

<img width="401" alt="image" src="https://github.com/captures-2024/soongan-backend/assets/101378867/2a1a7555-84a3-4f08-9a0c-3227eea7d04a">

https로 접근하면 서버에 접근이 됩니다. (아래 사진은 Security에 걸려서 오류가 발생하는 것)

<img width="713" alt="image" src="https://github.com/captures-2024/soongan-backend/assets/101378867/1bc82cec-c524-4225-ab23-720f882d8fc9">

# 참고 사항

p12 형식의 SSL 인증서 파일이 있는데 이건 보내드리겠습니다!
일단 배포 서버에 로드 밸런서가 없어서 서버 port를 443으로 설정해서 저희 도메인으로 https로 접근하면 서버로 접근하게 하려고 해놨는데, 이는 나중에 수정이 필요할 것 같습니다.
