### PR TITLE
JwtFilter에 passUrl은 통과하도록 수정

### DIFF
--- a/src/main/kotlin/com/soongan/soonganbackend/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/soongan/soonganbackend/config/SecurityConfig.kt
@@ -8,15 +8,13 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
-import org.springframework.stereotype.Component
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 class SecurityConfig(
-    private val jwtFilter: JwtFilter,
-    private val passUrls: PassUrls
+    private val jwtFilter: JwtFilter
 ) {
 
     @Bean
@@ -32,7 +30,7 @@ class SecurityConfig(
                 it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }
             .authorizeHttpRequests {
-                it.requestMatchers(*passUrls.get().toTypedArray()).permitAll()
+                it.requestMatchers(*Uri.passUris.toTypedArray()).permitAll()
                     .anyRequest().authenticated()
             }
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
@@ -53,19 +51,5 @@ class SecurityConfig(
         source.registerCorsConfiguration("/**", configuration)
 
         return source
-    }
-}
-
-@Component
-class PassUrls {
-    fun get(): List<String> {
-        return listOf(
-            Uri.MEMBERS + Uri.LOGIN,
-            Uri.MEMBERS + Uri.REFRESH,
-            Uri.API_DOCS,
-            Uri.SWAGGER_UI + "/**",
-            Uri.SWAGGER_RESOURCES + "/**",
-            Uri.V3 + Uri.API_DOCS + "/**"
-        )
     }
 }

--- a/src/main/kotlin/com/soongan/soonganbackend/filter/JwtFilter.kt
+++ b/src/main/kotlin/com/soongan/soonganbackend/filter/JwtFilter.kt
@@ -1,9 +1,9 @@
 package com.soongan.soonganbackend.filter
 
-import com.soongan.soonganbackend.config.PassUrls
 import com.soongan.soonganbackend.enums.TokenType
 import com.soongan.soonganbackend.service.jwt.JwtService
 import com.soongan.soonganbackend.persistence.member.MemberRepository
+import com.soongan.soonganbackend.util.common.constant.Uri
 import com.soongan.soonganbackend.util.common.exception.SoonganException
 import com.soongan.soonganbackend.util.common.exception.StatusCode
 import jakarta.servlet.FilterChain
@@ -17,12 +17,19 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class JwtFilter(
     private val jwtService: JwtService,
-    private val memberRepository: MemberRepository,
-    private val passUrls: PassUrls
+    private val memberRepository: MemberRepository
 ): OncePerRequestFilter() {
 
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
-        return passUrls.get().contains(request.requestURI)
+        val requestUri = request.requestURI
+
+        return Uri.passUris.any { passUri ->
+            if (passUri.endsWith("/**")) {
+                requestUri.startsWith(passUri.removeSuffix("/**"))
+            } else {
+                requestUri == passUri
+            }
+        }
     }
 
     override fun doFilterInternal(

--- a/src/main/kotlin/com/soongan/soonganbackend/util/common/constant/Uri.kt
+++ b/src/main/kotlin/com/soongan/soonganbackend/util/common/constant/Uri.kt
@@ -19,4 +19,13 @@ object Uri {
     const val CONTESTS = "/contests"
     const val POSTS = "/posts"
     const val LIKE = "/like"
+
+    val passUris = listOf(
+        MEMBERS + LOGIN,
+        MEMBERS + REFRESH,
+        API_DOCS,
+        SWAGGER_UI + "/**",
+        SWAGGER_RESOURCES + "/**",
+        V3 + API_DOCS + "/**"
+    )
 }


### PR DESCRIPTION
# 관련 이슈

#37 

# 구현 사항

JwtFilter에서 passUrl들을 받아 통과시키도록 하였습니다!
PassUrl이 SecurityConfig에서도 필요하고, JwtFilter에서도 필요해서 컴포넌트로 설정해 받아왔습니다
