### PR TITLE
Swagger docs 에서 LoginMember 제외

### DIFF
--- a/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/resolver/LoginMemberArgumentResolver.kt
+++ b/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/resolver/LoginMemberArgumentResolver.kt
@@ -5,6 +5,7 @@ import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import com.soongan.soonganbackend.soongansupport.util.dto.MemberDetail
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.core.MethodParameter
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
@@ -18,7 +19,9 @@ class LoginMemberArgumentResolver(
     private val memberAdapter: MemberAdapter
 ): HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return parameter.hasParameterAnnotation(LoginMember::class.java)
+        val hasParamAnnotation = parameter.hasParameterAnnotation(LoginMember::class.java)
+        val isValidParamType = MemberEntity::class.java.isAssignableFrom(parameter.parameterType)
+        return hasParamAnnotation && isValidParamType
     }
 
     override fun resolveArgument(parameter: MethodParameter, mavContainer: ModelAndViewContainer?, webRequest: NativeWebRequest, binderFactory: WebDataBinderFactory?): MemberEntity? {
@@ -30,4 +33,5 @@ class LoginMemberArgumentResolver(
 
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
+@Schema(hidden = true)
 annotation class LoginMember


### PR DESCRIPTION
# 관련이슈
#82 

# 변경사항
- Swagger Docs에서 `@LoginMember` 어노테이션으로 인해 Request Body에 MemberEntity가 노출되던 문제를 해결합니다.
- 일단 전역적으로 @LoginMember 어노테이션 사용되는 곳에서 MemberEntity 노출되지 않도록 지워두었습니다. MemberEntity가 Controller단에서 사용되는 것은 추후 변경해보겠습니다.