### PR TITLE
Weekly Contest Post 조회 시, query param의 round를 nullable 하도록 변경

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContestPost/WeeklyContestPostController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContestPost/WeeklyContestPostController.kt
@@ -32,7 +32,7 @@ class WeeklyContestPostController (
     @GetMapping
     @Operation(summary = "주간 콘테스트 게시글 조회 Api", description = "주간 콘테스트 게시글을 조회합니다. 라운드와 정렬 기준을 이용하여 조회할 수 있습니다.")
     fun getWeeklyContestPost(
-        @RequestParam round: Int,
+        @RequestParam(required = false) round: Int? = null,
         @RequestParam orderCriteria: WeeklyContestPostOrderCriteriaEnum,
         @RequestParam(required = false, defaultValue = "0") page: Int,
         @RequestParam(required = false, defaultValue = "50") pageSize: Int

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/home/HomeService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/home/HomeService.kt
@@ -1,6 +1,7 @@
 package com.soongan.soonganbackend.soonganapi.service.home
 
 import com.soongan.soonganbackend.soonganapi.interfaces.home.dto.response.HomeResponseDto
+import com.soongan.soonganbackend.soonganapi.service.weeklyContest.WeeklyContestValidator
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestEntity
@@ -13,18 +14,12 @@ import java.time.LocalDateTime
 
 @Service
 class HomeService(
-    private val weeklyContestAdapter: WeeklyContestAdapter,
-    private val weeklyContestPostAdapter: WeeklyContestPostAdapter
+    private val weeklyContestPostAdapter: WeeklyContestPostAdapter,
+    private val weeklyContestValidator: WeeklyContestValidator
 ) {
 
     fun getHome(loginMember: MemberEntity): HomeResponseDto {
-        val now = LocalDateTime.now()
-
-        // 진행 중인 Contest 없으면, 가장 최신 종료된 Contest 조회
-        val weeklyContest: WeeklyContestEntity = weeklyContestAdapter.getInProgressWeeklyContest(now)
-            ?: weeklyContestAdapter.getLatestEndedWeeklyContest(now)
-            ?: throw SoonganException(StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST)
-
+        val weeklyContest: WeeklyContestEntity = weeklyContestValidator.getWeeklyContestIfValidRound()
 
         val homeWeeklyContestPostList: List<WeeklyContestPostEntity> =
             weeklyContestPostAdapter.getAllWeeklyContestPostByMemberAndWeeklyContest(

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/WeeklyContestValidator.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/WeeklyContestValidator.kt
@@ -5,14 +5,27 @@ import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.Weekl
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
 
 @Component
 class WeeklyContestValidator(
     private val weeklyContestAdapter: WeeklyContestAdapter
 ) {
 
-    fun getWeeklyContestIfValidRound(round: Int): WeeklyContestEntity {
-        return weeklyContestAdapter.getWeeklyContest(round)
-            ?: throw SoonganException(StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST)
+    /**
+     * 주어진 라운드에 해당하는 주간 콘테스트를 반환한다.
+     * 라운드가 주어지지 않으면, 현재 진행 중인 주간 콘테스트를 반환한다.
+     * 현재 진행 중인 주간 콘테스트가 없으면, 가장 최신 종료된 주간 콘테스트를 반환한다.
+     */
+    fun getWeeklyContestIfValidRound(round: Int? = null): WeeklyContestEntity {
+        val now = LocalDateTime.now()
+
+        return round?.let {
+            weeklyContestAdapter.getWeeklyContest(round)
+                ?: throw SoonganException(StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST)
+        }
+            ?: weeklyContestAdapter.getInProgressWeeklyContest(now)
+        ?: weeklyContestAdapter.getLatestEndedWeeklyContest(now)
+        ?: throw SoonganException(StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST)
     }
 }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
@@ -27,7 +27,7 @@ class WeeklyContestService(
 
     @Transactional(readOnly = true)
     fun getWeeklyContestPostList(
-        round: Int,
+        round: Int?,
         orderCriteria: WeeklyContestPostOrderCriteriaEnum,
         page: Int,
         pageSize: Int


### PR DESCRIPTION
# 관련이슈
#107 

# Base on Branch

- develop

# 변경점

- Weekly Contest Post 조회 시, 기존에 query param에서 round를 필수적으로 받고 있었는데, 해당 부분을 제거합니다.
- 현재는 지나간 회차의 weekly contest를 조회하는 화면이 없어 round가 필요 없지만, 추후 생길 때를 대비해서 아예 제거는 하지 않았습니다.
  - FE께는 round 없이 호출하도록 가이드 드리도록 하겠습니다.

# Example/Screenshot (if any)

- https://discord.com/channels/1221820069026336850/1224367966397796498/1317716769116393582

# TODO

- [ ] local test     



