### PR TITLE
사진 게시물 등록 요청에서 weekly contest round 삭제

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContestPost/dto/request/WeeklyContestPostRegisterRequestDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContestPost/dto/request/WeeklyContestPostRegisterRequestDto.kt
@@ -1,13 +1,10 @@
 package com.soongan.soonganbackend.soonganapi.interfaces.weeklyContestPost.dto.request
 
-import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import org.springframework.web.multipart.MultipartFile
 
 data class WeeklyContestPostRegisterRequestDto(
-    @field:Min(1)
-    val weeklyContestRound: Int,
     @field:NotBlank
     val subject: String,
     @field:NotNull

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
@@ -73,7 +73,7 @@ class WeeklyContestService(
         request: WeeklyContestPostRegisterRequestDto
     ): WeeklyContestPostRegisterResponseDto {
         val weeklyContest: WeeklyContestEntity =
-            weeklyContestValidator.getWeeklyContestIfValidRound(request.weeklyContestRound)
+            weeklyContestValidator.getWeeklyContestIfValidRound()
 
         weeklyContestPostValidator.validateMaxRegisterPost(weeklyContest, loginMember)
 
@@ -81,7 +81,7 @@ class WeeklyContestService(
             request.imageFile,
             loginMember.id!!,
             ContestTypeEnum.WEEKLY,
-            request.weeklyContestRound
+            weeklyContest.round
         )
 
         val savedPost = weeklyContestPostAdapter.save(


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- 희훈님이 요청주신 사항으로, 사진 등록 시 round 정보 제외하고 최신 콘테스트에 등록하도록 변경하였습니다.

# Example/Screenshot (if any)

- 
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/481186ed-b5e6-4582-abe9-896af52d679e" />


# TODO

- [ ] local test     



