### PR TITLE
[captures2024-captures-2024#124] fix: passUris 에러 수정

### DIFF
--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/constant/Uri.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/constant/Uri.kt
@@ -1,6 +1,7 @@
 package com.soongan.soonganbackend.soongansupport.util.constant
 
 object Uri {
+    const val HEALTH = "/_health"
     const val V3 = "/v3"
     const val API = "/api"
     const val API_DOCS = "/api-docs"
@@ -40,23 +41,24 @@ object Uri {
     const val APPLE_LOGIN = "/apple_login"
     const val SUCCESS = "/success"
 
-    val passUris = listOf(
+    val passGetUris = listOf(
         "/_health",
         API_DOCS,
         SWAGGER_UI + "/**",
         SWAGGER_RESOURCES + "/**",
         V3 + API_DOCS + "/**",
 
-        AUTH + LOGIN,
-        AUTH + REFRESH,
-
         WEEKLY + CONTESTS + POSTS,
-
-        FCM,
-        FCM + "/test",
 
         CALLBACK + APPLE_LOGIN,
         CALLBACK + APPLE_LOGIN + SUCCESS
+    )
+    val passPostUris = listOf(
+        AUTH + LOGIN,
+        AUTH + REFRESH,
+
+        FCM,
+        FCM + "/test"
     )
 
     val notWrapUris = listOf(

--- a/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/config/SecurityConfig.kt
+++ b/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/config/SecurityConfig.kt
@@ -1,6 +1,5 @@
 package com.soongan.soonganbackend.soonganweb.config
 
-import com.soongan.soonganbackend.soongansupport.util.constant.Uri
 import com.soongan.soonganbackend.soonganweb.filter.JwtFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -28,10 +27,6 @@ class SecurityConfig(
             }
             .sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            }
-            .authorizeHttpRequests {
-                it.requestMatchers(*Uri.passUris.toTypedArray()).permitAll()
-                    .anyRequest().authenticated()
             }
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()

--- a/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/JwtFilter.kt
+++ b/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/JwtFilter.kt
@@ -25,12 +25,21 @@ class JwtFilter(
 
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
         val requestUri = request.requestURI
+        val requestMethod = request.method
 
-        return Uri.passUris.any { passUri ->
+        return when (requestMethod) {
+            "GET" -> isPass(requestUri, Uri.passGetUris)
+            "POST" -> isPass(requestUri, Uri.passPostUris)
+            else -> false
+        }
+    }
+
+    fun isPass(uri: String, passUris: List<String>): Boolean {
+        return passUris.any { passUri ->
             if (passUri.endsWith("/**")) {
-                requestUri.startsWith(passUri.removeSuffix("/**"))
+                uri.startsWith(passUri.removeSuffix("/**"))
             } else {
-                requestUri == passUri
+                uri == passUri
             }
         }
     }


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- /weekly/contests/posts가 passUris로 지정되어 있어서 JwtFilter를 통과해 @LoginMember에서 에러가 발생했었습니다.
- http 메서드별로 passUris를 구분하도록 하였습니다.

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



