### PR TITLE
fix: gcp storage 이미지 업로드 setContentDisposition값 변경

### DIFF
--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/service/GcpStorageService.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/service/GcpStorageService.kt
@@ -33,7 +33,10 @@ class GcpStorageService(
     }
 
     private fun uploadImage(blobId: BlobId, file: MultipartFile): String {
-        val blobInfo = BlobInfo.newBuilder(blobId).setContentType(file.contentType).build()
+        val blobInfo = BlobInfo.newBuilder(blobId)
+            .setContentType(file.contentType)
+            .setContentDisposition("inline")
+            .build()
         gcpStorage.create(blobInfo, file.inputStream.readBytes())
         return "https://storage.cloud.google.com/${blobId.bucket}/${blobId.name}"
     }


### PR DESCRIPTION
# 관련이슈

#120 

# Base on Branch

- develop

# 변경점

- GcpStorageService에서 setContentDisposition값 inline 설정

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



