### PR TITLE
feat: 프로필 변경 api에 닉네임 중복 검사 로직 추가

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
@@ -5,6 +5,8 @@ import com.soongan.soonganbackend.soonganapi.interfaces.member.dto.response.*
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import com.soongan.soonganbackend.soongansupport.service.GcpStorageService
+import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
+import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -35,6 +37,10 @@ class MemberService(
 
     @Transactional
     fun updateProfile(loginMember: MemberEntity, request: UpdateProfileRequestDto): UpdateProfileResponseDto {
+        if (request.nickname != null && request.nickname != loginMember.nickname && this.checkNickname(request.nickname).not()) {
+            throw SoonganException(StatusCode.SOONGAN_API_DUPLICATED_NICKNAME, "닉네임이 중복됩니다.")
+        }
+
         val oldProfileImageUrl = loginMember.profileImageUrl
         val updateProfileImageUrl = request.profileImage?.let {
             gcpStorageService.uploadProfileImage(it, loginMember.id!!)

--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/exception/StatusCode.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/exception/StatusCode.kt
@@ -22,6 +22,7 @@ enum class StatusCode(val code: Int, val message: String) {
     SOONGAN_MEMBER_API_FAIL_TO_LOGOUT(701, "Fail to Logout"),
     SOONGAN_API_BANNED_MEMBER(702, "Banned Member"),
     SOONGAN_API_WITHDRAWN_MEMBER(703, "Withdrawn Member"),
+    SOONGAN_API_DUPLICATED_NICKNAME(704, "Duplicated Nickname"),
 
     // 800 ~ 899 FCM Status Code
     SOONGAN_API_ALREADY_EXIST_FCM_TOKEN(800, "Already Exist FCM Token"),


### PR DESCRIPTION
# 관련이슈

#127 

# Base on Branch

- develop

# 변경점

- 프로필 변경 로직에 변경하려는 닉네임이 내 닉네임이 아닌 경우 중복 검사 로직 추가

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



