### PR TITLE
[captures2024-captures-2024#131] fix: 주간 콘테스트 최대 업로드 수 제한 문제 수정

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/validator/WeeklyContestPostValidator.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/validator/WeeklyContestPostValidator.kt
@@ -19,7 +19,7 @@ class WeeklyContestPostValidator(
     ) {
         val registeredPostCount = weeklyContestPostAdapter.countRegisteredPostByMember(weeklyContest, member)
 
-        if (weeklyContest.maxPostAllowed <= registeredPostCount + 1) {
+        if (weeklyContest.maxPostAllowed <= registeredPostCount) {
             throw (SoonganException(StatusCode.SOONGAN_API_WEEKLY_CONTEST_POST_REGISTER_LIMIT_EXCEEDED))
         }
     }

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/weeklyContestPost/validator/WeeklyContestPostValidatorTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/weeklyContestPost/validator/WeeklyContestPostValidatorTest.kt
@@ -36,7 +36,7 @@ class WeeklyContestPostValidatorTest {
             round = 1,
             maxPostAllowed = 3
         )
-        val registeredPostCountByMember = 2
+        val registeredPostCountByMember = 3
 
         every { weeklyContestPostAdapter.countRegisteredPostByMember(weeklyContest, member) } returns registeredPostCountByMember
 


### PR DESCRIPTION
# 관련이슈

#131 

# Base on Branch

- develop

# 변경점

- 최대 업로드 수 제한 조건식 해결, 관련 테스트 코드 수정

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



