### PR TITLE
Register ObjectMapper as Spring bean

### DIFF
--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/config/ObjectMapperConfig.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/config/ObjectMapperConfig.kt
@@ -1,0 +1,24 @@
+package com.soongan.soonganbackend.soongansupport.config
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ObjectMapperConfig {
+
+    @Bean
+    fun objectMapper() = ObjectMapper().apply {
+        val kotlinModule = KotlinModule.Builder()
+            .build()
+
+        registerModule(kotlinModule)
+        disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+        disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+        disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+    }
+}


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- ObjectMapper를 스프링 빈으로 등록하여 사용
- ObjectMapper에 Kotlin 직렬화/역직렬화에 필요한 설정 추가 (KotlinModule)
- Generic 타입을 대비하여 예외 터지는 것 낙관적으로 비활성화
- nanosecond 까지 직렬화/역직렬화하는 것 비활성화 (milliseconds까지)

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



