### PR TITLE
accessToken이 없는 경우 필터 체인 계속 진행하도록 JwtFilter 수정

### DIFF
--- a/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/JwtFilter.kt
+++ b/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/JwtFilter.kt
@@ -49,21 +49,23 @@ class JwtFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        try {
-            val accessToken = request.getHeader("Authorization")?.substringAfter("Bearer ")
-                ?: throw SoonganUnauthorizedException(StatusCode.MISSING_JWT)
+        val accessToken = request.getHeader("Authorization")?.substringAfter("Bearer ")
 
-            val payload = jwtHandler.getPayload(accessToken, JwtTypeEnum.ACCESS)
-            val email = payload["sub"] as String
-
-            val auth = UsernamePasswordAuthenticationToken(email, null, listOf())
-            SecurityContextHolder.getContext().authentication = auth
-            filterChain.doFilter(request, response)
-        } catch (sue: SoonganUnauthorizedException) {
-            kLogger.error { "${sue.statusCode} \n ${sue.stackTraceToString()}" }
-            val errorResponse = CommonErrorResponseDto.from(StatusCode.UNAUTHORIZED)    // client 추상화된 에러 제공
-            HttpMvcResponseJsonConverter.writeJsonResponse(response, errorResponse)
+        if (!accessToken.isNullOrBlank()) {  // accessToken이 있는데 유효하지 않으면 에러
+            try {
+                val payload = jwtHandler.getPayload(accessToken, JwtTypeEnum.ACCESS)
+                val email = payload["sub"] as String
+                val auth = UsernamePasswordAuthenticationToken(email, null, listOf())
+                SecurityContextHolder.getContext().authentication = auth
+            } catch (sue: SoonganUnauthorizedException) {
+                kLogger.error { "${sue.statusCode} \n ${sue.stackTraceToString()}" }
+                val errorResponse = CommonErrorResponseDto.from(StatusCode.UNAUTHORIZED)
+                HttpMvcResponseJsonConverter.writeJsonResponse(response, errorResponse)
+                return
+            }
         }
 
+        // accessToken이 없는 경우는 그냥 계속 필터 체인을 진행하도록 허용 (나중에 @LoginMember에서 throwIfUnauthorized가 true인 경우에 처리)
+        filterChain.doFilter(request, response)
     }
 }


### PR DESCRIPTION
# 관련이슈

#156 

# Base on Branch

- develop

# 변경점

JwtFilter에서 accessToken이 없어도 그냥 통과하도록 수정했습니다.
이유는 게시글 상세 조회(weekly/posts/{postId})의 경우 전에 @LoginMember(throwIfUnauthorize = false)로 처리했었는데, 사실 @LoginMember에 오기도 전에 JwtFilter에서 토큰이 유효하지 않으면 에러가 발생했습니다. (throwIfUnauthorize를 달아준 의미가 없음)
Uri의 passUri들에 추가하려면 로그인한 유저 마저도 JwtFilter에서 인증 정보를 달아주지 못해 무조건 인증 정보를 못넘겨주기 때문에 수정했습니다.
클라 요청에 토큰이 아예 없이 날라오면 필터는 무조건 통과하고, @LoginMember에서 막히도록 했습니다.


# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



