### PR TITLE
fix: post-like 테이블 contest_type, post_id 인덱스 유니크 설정 제거

### DIFF
--- a/.github/workflows/on-pull-request-api-dev.yml
+++ b/.github/workflows/on-pull-request-api-dev.yml
@@ -30,5 +30,5 @@ jobs:
           export INFISICAL_TOKEN=${{ secrets.INFISICAL_TOKEN_API_DEV }}
           export INFISICAL_PROJECT_ID=${{ secrets.INFISICAL_PROJECT_ID_API }}
           export SPRING_PROFILES_ACTIVE=local
-          infisical run --env=local -- ./gradlew :soongan-api:build
+          infisical run --token=${{ secrets.INFISICAL_TOKEN_API_DEV }} --projectId=${{ secrets.INFISICAL_PROJECT_ID_API }} --env=local -- ./gradlew :soongan-api:build
 # TODO: 인피지컬 환경 test 추가 필요

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/postLike/dto/request/PostLikeRequestDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/postLike/dto/request/PostLikeRequestDto.kt
@@ -10,7 +10,7 @@ data class PostLikeRequestDto (
     @field:NotNull
     val postId: Long,
 
-    @Schema(description = "대회 타입 (weekly/daily)", required = true)
+    @Schema(description = "대회 타입 (WEEKLY/DAILY)", required = true)
     @field:NotNull
     val contestType: ContestTypeEnum
 )

--- a/libs/soongan-persistence/src/main/resources/sql/ddl/004-post_like.sql
+++ b/libs/soongan-persistence/src/main/resources/sql/ddl/004-post_like.sql
@@ -9,4 +9,4 @@ create table post_like
 );
 
 create index post_like_idx_member_id on post_like (member_id);
-create unique index post_like_uidx_contest_type_post_id on post_like (contest_type, post_id);
+create index post_like_idx_contest_type_post_id on post_like (contest_type, post_id);


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- post_like 테이블에 contest_type, post_id로 유니크 인덱스가 걸려 있어서 해당 post에 좋아요가 1개밖에 달리지 못하는 상황이었습니다.
- unique 설정 제거

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



