### PR TITLE
게시물/댓글 신고시 또는 유저 본인 정보 조회시 유저가 지금까지 신고한 내역 내려주도록 수정

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/MemberInfoResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/MemberInfoResponseDto.kt
@@ -2,6 +2,7 @@ package com.soongan.soonganbackend.soonganapi.interfaces.member.dto.response
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
+import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportEntity
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "회원 정보 응답 DTO")
@@ -20,16 +21,47 @@ data class MemberInfoResponseDto(
     val profileImageUrl: String?,
 
     @Schema(description = "자기소개")
-    val selfIntroduction: String?
+    val selfIntroduction: String?,
+
+    @Schema(description = "유저가 신고한 내역")
+    val reportHistories: List<ReportHistoryResponseDto>
 ) {
     companion object {
-        fun from(member: MemberEntity): MemberInfoResponseDto {
+        fun from(member: MemberEntity, reportHistories: List<ReportEntity>): MemberInfoResponseDto {
+            val reportHistoryResponseDtos = reportHistories.map { reportHistory ->
+                ReportHistoryResponseDto.from(reportHistory)
+            }
+
             return MemberInfoResponseDto(
                 email = member.email,
                 nickname = member.nickname,
                 birthYear = member.birthYear,
                 profileImageUrl = member.profileImageUrl,
-                selfIntroduction = member.selfIntroduction
+                selfIntroduction = member.selfIntroduction,
+                reportHistories = reportHistoryResponseDtos
+            )
+        }
+    }
+}
+
+
+@Schema(description = "유저 신고 내역 응답 DTO")
+data class ReportHistoryResponseDto(
+    @Schema(description = "신고 ID", required = true)
+    val id: Long,
+
+    @Schema(description = "신고 대상 ID", required = true)
+    val targetId: Long,
+
+    @Schema(description = "신고 대상 타입 (post/comment)", required = true)
+    val targetType: String,
+) {
+    companion object {
+        fun from(report: ReportEntity): ReportHistoryResponseDto {
+            return ReportHistoryResponseDto(
+                id = report.id!!,
+                targetId = report.targetId,
+                targetType = report.targetType.name,
             )
         }
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/MemberInfoResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/MemberInfoResponseDto.kt
@@ -1,6 +1,7 @@
 package com.soongan.soonganbackend.soonganapi.interfaces.member.dto.response
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.soongan.soonganbackend.soonganapi.interfaces.report.dto.response.ReportHistoryResponseDto
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportEntity
 import io.swagger.v3.oas.annotations.media.Schema
@@ -39,29 +40,6 @@ data class MemberInfoResponseDto(
                 profileImageUrl = member.profileImageUrl,
                 selfIntroduction = member.selfIntroduction,
                 reportHistories = reportHistoryResponseDtos
-            )
-        }
-    }
-}
-
-
-@Schema(description = "유저 신고 내역 응답 DTO")
-data class ReportHistoryResponseDto(
-    @Schema(description = "신고 ID", required = true)
-    val id: Long,
-
-    @Schema(description = "신고 대상 ID", required = true)
-    val targetId: Long,
-
-    @Schema(description = "신고 대상 타입 (post/comment)", required = true)
-    val targetType: String,
-) {
-    companion object {
-        fun from(report: ReportEntity): ReportHistoryResponseDto {
-            return ReportHistoryResponseDto(
-                id = report.id!!,
-                targetId = report.targetId,
-                targetType = report.targetType.name,
             )
         }
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/report/dto/response/ReportHistoriesResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/report/dto/response/ReportHistoriesResponseDto.kt
@@ -1,0 +1,26 @@
+package com.soongan.soonganbackend.soonganapi.interfaces.report.dto.response
+
+import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportEntity
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "유저 신고 내역 응답 DTO")
+data class ReportHistoryResponseDto(
+    @Schema(description = "신고 ID", required = true)
+    val id: Long,
+
+    @Schema(description = "신고 대상 ID", required = true)
+    val targetId: Long,
+
+    @Schema(description = "신고 대상 타입 (post/comment)", required = true)
+    val targetType: String,
+) {
+    companion object {
+        fun from(report: ReportEntity): ReportHistoryResponseDto {
+            return ReportHistoryResponseDto(
+                id = report.id!!,
+                targetId = report.targetId,
+                targetType = report.targetType.name,
+            )
+        }
+    }
+}

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/report/dto/response/ReportSaveResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/report/dto/response/ReportSaveResponseDto.kt
@@ -26,9 +26,12 @@ data class ReportSaveResponseDto(
 
     @Schema(description = "신고 사유", required = false)
     val reason: String?,
+
+    @Schema(description = "유저가 신고한 내역", required = true)
+    val reportHistories: List<ReportHistoryResponseDto>
 ) {
     companion object {
-        fun from(reportEntity: ReportEntity): ReportSaveResponseDto {
+        fun from(reportEntity: ReportEntity, reportHistories: List<ReportEntity>): ReportSaveResponseDto {
             return ReportSaveResponseDto(
                 id = reportEntity.id!!,
                 reportMemberId = reportEntity.reportMember.id!!,
@@ -37,6 +40,9 @@ data class ReportSaveResponseDto(
                 targetType = reportEntity.targetType.name,
                 reportType = reportEntity.reportType,
                 reason = reportEntity.reason,
+                reportHistories = reportHistories.map { reportHistory ->
+                    ReportHistoryResponseDto.from(reportHistory)
+                }
             )
         }
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
@@ -4,6 +4,7 @@ import com.soongan.soonganbackend.soonganapi.interfaces.member.dto.request.Updat
 import com.soongan.soonganbackend.soonganapi.interfaces.member.dto.response.*
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
+import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportAdapter
 import com.soongan.soonganbackend.soongansupport.service.GcpStorageService
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
@@ -13,10 +14,12 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class MemberService(
     private val memberAdapter: MemberAdapter,
+    private val reportAdapter: ReportAdapter,
     private val gcpStorageService: GcpStorageService,
 ) {
     fun getMemberInfo(loginMember: MemberEntity): MemberInfoResponseDto {
-        return MemberInfoResponseDto.from(loginMember)
+        val reportHistories = reportAdapter.getReportHistoriesByReportMember(loginMember)
+        return MemberInfoResponseDto.from(loginMember, reportHistories)
     }
 
     @Transactional(readOnly = true)

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/report/ReportService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/report/ReportService.kt
@@ -43,6 +43,8 @@ class ReportService(
             )
         )
 
-        return ReportSaveResponseDto.from(savedReport)
+        val reportHistories = reportAdapter.getReportHistoriesByReportMember(loginMember)
+
+        return ReportSaveResponseDto.from(savedReport, reportHistories)
     }
 }

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/member/MemberServiceTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/member/MemberServiceTest.kt
@@ -1,9 +1,11 @@
 package com.soongan.soonganbackend.soonganapi.unit.service.member
 
 import com.soongan.soonganbackend.soonganapi.interfaces.member.dto.request.UpdateProfileRequestDto
+import com.soongan.soonganbackend.soonganapi.interfaces.report.dto.response.ReportHistoryResponseDto
 import com.soongan.soonganbackend.soonganapi.service.member.MemberService
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
+import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportAdapter
 import com.soongan.soonganbackend.soongansupport.domain.ProviderEnum
 import com.soongan.soonganbackend.soongansupport.service.GcpStorageService
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
@@ -26,6 +28,9 @@ class MemberServiceTest {
     @MockK
     private lateinit var gcpStorageService: GcpStorageService
 
+    @MockK
+    private lateinit var reportAdapter: ReportAdapter
+
     @InjectMockKs
     private lateinit var memberService: MemberService
 
@@ -42,18 +47,22 @@ class MemberServiceTest {
             selfIntroduction = "test-self-introduction"
         )
 
+        // mock
+        every { reportAdapter.getReportHistoriesByReportMember(loginMember) } returns emptyList()
+
         // when
         val result = memberService.getMemberInfo(loginMember)
 
         // then
         assertThat(result)
-            .extracting("email", "nickname", "birthYear", "profileImageUrl", "selfIntroduction")
+            .extracting("email", "nickname", "birthYear", "profileImageUrl", "selfIntroduction", "reportHistories")
             .containsExactly(
                 loginMember.email,
                 loginMember.nickname,
                 loginMember.birthYear,
                 loginMember.profileImageUrl,
-                loginMember.selfIntroduction
+                loginMember.selfIntroduction,
+                emptyList<ReportHistoryResponseDto>()
             )
     }
 

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/report/ReportServiceTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/report/ReportServiceTest.kt
@@ -1,6 +1,7 @@
 package com.soongan.soonganbackend.soonganapi.unit.service.report
 
 import com.soongan.soonganbackend.soonganapi.interfaces.report.dto.request.ReportSaveRequestDto
+import com.soongan.soonganbackend.soonganapi.interfaces.report.dto.response.ReportHistoryResponseDto
 import com.soongan.soonganbackend.soonganapi.service.report.ReportService
 import com.soongan.soonganbackend.soonganpersistence.storage.comment.CommentAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
@@ -66,6 +67,7 @@ class ReportServiceTest {
         // mock
         every { weeklyContestPostAdapter.getByIdOrNull(any()) } returns post
         every { reportAdapter.save(any()) } returns report
+        every { reportAdapter.getReportHistoriesByReportMember(loginMember) } returns listOf(report)
 
         // when
         val result = reportService.report(loginMember, request)
@@ -79,7 +81,8 @@ class ReportServiceTest {
                 "targetId",
                 "targetType",
                 "reportType",
-                "reason"
+                "reason",
+                "reportHistories"
             )
             .containsExactly(
                 report.id,
@@ -88,7 +91,8 @@ class ReportServiceTest {
                 post.id,
                 ReportTargetTypeEnum.WEEKLY_POST.name,
                 ReportTypeEnum.SPAM,
-                request.reason
+                request.reason,
+                listOf(ReportHistoryResponseDto.from(report))
             );
     }
 

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/report/ReportAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/report/ReportAdapter.kt
@@ -1,5 +1,6 @@
 package com.soongan.soonganbackend.soonganpersistence.storage.report
 
+import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,5 +12,10 @@ class ReportAdapter(
     @Transactional
     fun save(reportEntity: ReportEntity): ReportEntity {
         return reportRepository.save(reportEntity)
+    }
+
+    @Transactional(readOnly = true)
+    fun getReportHistoriesByReportMember(loginMember: MemberEntity): List<ReportEntity> {
+        return reportRepository.findByReportMember(loginMember)
     }
 }

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/report/ReportEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/report/ReportEntity.kt
@@ -35,9 +35,11 @@ data class ReportEntity(
     val targetId: Long,
 
     @Column(name = "target_type", nullable = false)
+    @Enumerated(EnumType.STRING)
     val targetType: ReportTargetTypeEnum,
 
     @Column(name = "report_type", nullable = false)
+    @Enumerated(EnumType.STRING)
     val reportType: ReportTypeEnum,
 
     @Column(name = "reason", nullable = true)

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/report/ReportRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/report/ReportRepository.kt
@@ -1,5 +1,8 @@
 package com.soongan.soonganbackend.soonganpersistence.storage.report
 
+import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ReportRepository: JpaRepository<ReportEntity, Long>
+interface ReportRepository: JpaRepository<ReportEntity, Long> {
+    fun findByReportMember(reportMember: MemberEntity): List<ReportEntity>
+}


### PR DESCRIPTION
# 관련이슈

#155 

# Base on Branch

- develop

# 변경점

신고 내역 안보이게 처리 어떻게 할까 하다가 희훈님께서 아이디어를 내주셔서 처리했습니다.
신고하기 API 혹은 본인 정보 조회 API에서 지금까지 신고한 내역을 같이 내려줘서 앱 내에서 신고 내역을 저장하는 것으로 했습니다.

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



