### PR TITLE
refactor: JwtFilter, ApiKeyFilter에서 response status값 설정

### DIFF
--- a/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/ApiKeyFilter.kt
+++ b/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/ApiKeyFilter.kt
@@ -29,6 +29,7 @@ class ApiKeyFilter(
             filterChain.doFilter(request, response)
         } else {
             val errorResponse = CommonErrorResponseDto.from(StatusCode.FORBIDDEN)
+            response.status = errorResponse.statusCode
             HttpMvcResponseJsonConverter.writeJsonResponse(response, errorResponse)
             return
         }

--- a/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/JwtFilter.kt
+++ b/libs/soongan-web/src/main/kotlin/com/soongan/soonganbackend/soonganweb/filter/JwtFilter.kt
@@ -51,6 +51,7 @@ class JwtFilter(
             } catch (sue: SoonganUnauthorizedException) {
                 kLogger.error { "${sue.statusCode} \n ${sue.stackTraceToString()}" }
                 val errorResponse = CommonErrorResponseDto.from(StatusCode.UNAUTHORIZED)
+                response.status = errorResponse.statusCode
                 HttpMvcResponseJsonConverter.writeJsonResponse(response, errorResponse)
                 return
             }


### PR DESCRIPTION
# 관련이슈

#178 

# Base on Branch

- develop

# 변경점

- JwtFilter, ApiKeyFilter에 response status값 설정

# Example/Screenshot (if any)

- 

# TODO

- [x] local test     



