### PR TITLE
역대 주간 콘테스트 조회 api 추가

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/WeeklyContestController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/WeeklyContestController.kt
@@ -40,10 +40,10 @@ class WeeklyContestController (
     }
 
     @Operation(
-        summary = "특정 주간 콘테스트 조회",
-        description = "특정 주간 콘테스트를 상세 조회합니다. 해당 콘테스트의 1차 투표 상위 7개 게시글을 함께 조회합니다."
+        summary = "특정 역대 주간 콘테스트 조회",
+        description = "특정 역대 주간 콘테스트를 상세 조회합니다. 해당 콘테스트의 1차 투표 상위 7개 게시글을 함께 조회합니다."
     )
-    @GetMapping("/{contestId}")
+    @GetMapping(Uri.HISTORIES + "/{contestId}")
     fun getWeeklyContestDetail(@PathVariable contestId: Long): WeeklyContestDetailResponseDto {
         return weeklyContestService.getWeeklyContestDetail(contestId)
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/WeeklyContestController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/WeeklyContestController.kt
@@ -34,9 +34,18 @@ class WeeklyContestController (
         summary = "역대 주간 콘테스트 조회",
         description = "역대 주간 콘테스트 리스트를 조회합니다."
     )
-    @GetMapping
+    @GetMapping(Uri.HISTORIES)
     fun getWeeklyContestList(): WeeklyContestListResponseDto {
         return weeklyContestService.getWeeklyContestList()
+    }
+
+    @Operation(
+        summary = "특정 주간 콘테스트 조회",
+        description = "특정 주간 콘테스트를 상세 조회합니다. 해당 콘테스트의 1차 투표 상위 7개 게시글을 함께 조회합니다."
+    )
+    @GetMapping("/{contestId}")
+    fun getWeeklyContestDetail(@PathVariable contestId: Long): WeeklyContestDetailResponseDto {
+        return weeklyContestService.getWeeklyContestDetail(contestId)
     }
 
     @Operation(

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
@@ -2,7 +2,6 @@ package com.soongan.soonganbackend.soonganapi.interfaces.weeklyContest.dto.respo
 
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal.WeeklyContestFinalEntity
 import io.swagger.v3.oas.annotations.media.Schema
-import java.math.BigDecimal
 
 @Schema(description = "역대 주간 콘테스트 상세 조회 응답 DTO")
 data class WeeklyContestDetailResponseDto(

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
@@ -1,0 +1,40 @@
+package com.soongan.soonganbackend.soonganapi.interfaces.weeklyContest.dto.response
+
+import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal.WeeklyContestFinalEntity
+import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
+
+@Schema(description = "역대 주간 콘테스트 상세 조회 응답 DTO")
+data class WeeklyContestDetailResponseDto(
+    val postsCount: Int,
+    val top7Posts: List<TopPostResponseDto>
+) {
+    @Schema(description = "역대 주간 콘테스트 상위 게시글 응답 DTO")
+    data class TopPostResponseDto(
+        val id: Long,
+        val postId: Long,
+        val nickname: String?,
+        val score: Int,
+    ) {
+
+        companion object {
+            fun from(weeklyContestFinalEntity: WeeklyContestFinalEntity): TopPostResponseDto {
+                return TopPostResponseDto(
+                    id = weeklyContestFinalEntity.id!!,
+                    postId = weeklyContestFinalEntity.weeklyContestPost.id!!,
+                    nickname = weeklyContestFinalEntity.weeklyContestPost.member.nickname,
+                    score = weeklyContestFinalEntity.score
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun from(postsCount: Int, top7Posts: List<WeeklyContestFinalEntity>): WeeklyContestDetailResponseDto {
+            return WeeklyContestDetailResponseDto(
+                postsCount = postsCount,
+                top7Posts = top7Posts.map { TopPostResponseDto.from(it) }
+            )
+        }
+    }
+}

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
@@ -14,6 +14,7 @@ data class WeeklyContestDetailResponseDto(
         val id: Long,
         val postId: Long,
         val nickname: String?,
+        val ranking: Int?,
         val score: Int,
     ) {
 
@@ -23,6 +24,7 @@ data class WeeklyContestDetailResponseDto(
                     id = weeklyContestFinalEntity.id!!,
                     postId = weeklyContestFinalEntity.weeklyContestPost.id!!,
                     nickname = weeklyContestFinalEntity.weeklyContestPost.member.nickname,
+                    ranking = weeklyContestFinalEntity.ranking,
                     score = weeklyContestFinalEntity.score
                 )
             }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestDetailResponseDto.kt
@@ -6,22 +6,44 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "역대 주간 콘테스트 상세 조회 응답 DTO")
 data class WeeklyContestDetailResponseDto(
     val postsCount: Int,
-    val top7Posts: List<TopPostResponseDto>
+    val firstPrizePost: FirstPrizePostResponseDto,
+    val otherTop7Posts: List<TopPostResponseDto>
 ) {
+    @Schema(description = "역대 주간 콘테스트 1위 게시글 응답 DTO")
+    data class FirstPrizePostResponseDto(
+        val postId: Long,
+        val title: String,
+        val imageUrl: String,
+        val nickname: String?,
+        val score: Int,
+    ) {
+        companion object {
+            fun from(weeklyContestFinalEntity: WeeklyContestFinalEntity): FirstPrizePostResponseDto {
+                return FirstPrizePostResponseDto(
+                    postId = weeklyContestFinalEntity.weeklyContestPost.id!!,
+                    title = weeklyContestFinalEntity.weeklyContestPost.title,
+                    imageUrl = weeklyContestFinalEntity.weeklyContestPost.imageUrl,
+                    nickname = weeklyContestFinalEntity.weeklyContestPost.member.nickname,
+                    score = weeklyContestFinalEntity.score
+                )
+            }
+        }
+    }
+
     @Schema(description = "역대 주간 콘테스트 상위 게시글 응답 DTO")
     data class TopPostResponseDto(
-        val id: Long,
         val postId: Long,
+        val imageUrl: String,
         val nickname: String?,
-        val ranking: Int?,
+        val ranking: Int,
         val score: Int,
     ) {
 
         companion object {
             fun from(weeklyContestFinalEntity: WeeklyContestFinalEntity): TopPostResponseDto {
                 return TopPostResponseDto(
-                    id = weeklyContestFinalEntity.id!!,
                     postId = weeklyContestFinalEntity.weeklyContestPost.id!!,
+                    imageUrl = weeklyContestFinalEntity.weeklyContestPost.imageUrl,
                     nickname = weeklyContestFinalEntity.weeklyContestPost.member.nickname,
                     ranking = weeklyContestFinalEntity.ranking,
                     score = weeklyContestFinalEntity.score
@@ -32,9 +54,16 @@ data class WeeklyContestDetailResponseDto(
 
     companion object {
         fun from(postsCount: Int, top7Posts: List<WeeklyContestFinalEntity>): WeeklyContestDetailResponseDto {
+            if (top7Posts.isEmpty()) {
+                throw IllegalArgumentException("Top posts list cannot be empty")
+            }
+            val sortedTop7Posts = top7Posts.sortedBy { it.ranking }
+            val firstPrizePost = FirstPrizePostResponseDto.from(sortedTop7Posts.first())
+            val otherTop7Posts = sortedTop7Posts.drop(1).map { TopPostResponseDto.from(it) }
             return WeeklyContestDetailResponseDto(
                 postsCount = postsCount,
-                top7Posts = top7Posts.map { TopPostResponseDto.from(it) }
+                firstPrizePost = firstPrizePost,
+                otherTop7Posts = otherTop7Posts
             )
         }
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestListResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestListResponseDto.kt
@@ -33,24 +33,24 @@ data class WeeklyContestListResponseDto(
 
         @Schema(required = true, description = "주간 콘테스트 공지 일자")
         val announcedAt: LocalDateTime,
-    )
 
-    companion object {
-        fun from(weeklyContests: List<WeeklyContestEntity>): WeeklyContestListResponseDto {
-            return WeeklyContestListResponseDto(
-                contests = weeklyContests.map {
-                    WeeklyContestDto(
-                        id = it.id!!,
-                        round = it.round,
-                        subject = it.subject,
-                        startAt = it.startAt,
-                        endAt = it.endAt,
-                        voteStartAt = it.voteStartAt,
-                        voteEndAt = it.voteEndAt,
-                        announcedAt = it.announcedAt,
-                    )
-                }
-            )
+        @Schema(required = true, description = "썸네일 이미지 URL (해당 콘테스트 1등 게시글 이미지)")
+        val thumbnailImageUrl: String,
+    ) {
+        companion object {
+            fun from(entity: WeeklyContestEntity, thumbnailImageUrl: String): WeeklyContestDto {
+                return WeeklyContestDto(
+                    id = entity.id!!,
+                    round = entity.round,
+                    subject = entity.subject,
+                    startAt = entity.startAt,
+                    endAt = entity.endAt,
+                    voteStartAt = entity.voteStartAt,
+                    voteEndAt = entity.voteEndAt,
+                    announcedAt = entity.announcedAt,
+                    thumbnailImageUrl = thumbnailImageUrl,
+                )
+            }
         }
     }
 }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestListResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestListResponseDto.kt
@@ -25,12 +25,6 @@ data class WeeklyContestListResponseDto(
         @Schema(required = true, description = "주간 콘테스트 종료 일자")
         val endAt: LocalDateTime,
 
-        @Schema(required = true, description = "주간 콘테스트 투표 시작 일자")
-        val voteStartAt: LocalDateTime,
-
-        @Schema(required = true, description = "주간 콘테스트 투표 종료 일자")
-        val voteEndAt: LocalDateTime,
-
         @Schema(required = true, description = "주간 콘테스트 공지 일자")
         val announcedAt: LocalDateTime,
 
@@ -45,8 +39,6 @@ data class WeeklyContestListResponseDto(
                     subject = entity.subject,
                     startAt = entity.startAt,
                     endAt = entity.endAt,
-                    voteStartAt = entity.voteStartAt,
-                    voteEndAt = entity.voteEndAt,
                     announcedAt = entity.announcedAt,
                     thumbnailImageUrl = thumbnailImageUrl,
                 )

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
@@ -18,6 +18,7 @@ import com.soongan.soonganbackend.soongansupport.domain.ContestTypeEnum
 import com.soongan.soonganbackend.soongansupport.domain.WeeklyContestPostOrderCriteriaEnum
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
+import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode.SOONGAN_API_CANNOT_UPDATE_POST_AFTER_VOTE_END
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
@@ -154,8 +155,8 @@ class WeeklyContestService(
         val weeklyContest = weeklyContestValidator.getWeeklyContestIfValidRound()
 
         val now = LocalDateTime.now()
-        if (weeklyContest.voteStartAt.isBefore(now)) {
-            throw SoonganException(StatusCode.SOONGAN_API_CANNOT_UPDATE_POST_AFTER_STARTING_VOTE)
+        if (weeklyContest.endAt.isBefore(now)) {
+            throw SoonganException(SOONGAN_API_CANNOT_UPDATE_POST_AFTER_VOTE_END)
         }
 
         val validatedPost = weeklyContestPostValidator.validatePostOwner(loginMember, postId)

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
@@ -13,6 +13,7 @@ import com.soongan.soonganbackend.soongansupport.domain.WeeklyContestPostOrderCr
 import com.soongan.soonganbackend.soonganapi.service.weeklyContestPost.validator.WeeklyContestPostValidator
 import com.soongan.soonganbackend.soonganpersistence.storage.postLike.PostLikeAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestAdapter
+import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal.WeeklyContestFinalAdapter
 import com.soongan.soonganbackend.soongansupport.domain.ContestTypeEnum
 import com.soongan.soonganbackend.soongansupport.domain.WeeklyContestPostOrderCriteriaEnum
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
@@ -27,6 +28,7 @@ import java.time.LocalDateTime
 class WeeklyContestService(
     private val weeklyContestAdapter: WeeklyContestAdapter,
     private val weeklyContestPostAdapter: WeeklyContestPostAdapter,
+    private val weeklyContestFinalAdapter: WeeklyContestFinalAdapter,
     private val gcpStorageService: GcpStorageService,
     private val weeklyContestPostValidator: WeeklyContestPostValidator,
     private val weeklyContestValidator: WeeklyContestValidator,
@@ -38,6 +40,13 @@ class WeeklyContestService(
         // 1차 투표가 끝난 주간 콘테스트들만 조회
         val weeklyContestList: List<WeeklyContestEntity> = weeklyContestAdapter.getEndedWeeklyContests()
         return WeeklyContestListResponseDto.from(weeklyContestList)
+    }
+
+    @Transactional(readOnly = true)
+    fun getWeeklyContestDetail(contestId: Long): WeeklyContestDetailResponseDto {
+        val postsCount = weeklyContestPostAdapter.countByWeeklyContestId(contestId)
+        val top7Posts = weeklyContestFinalAdapter.getFinalPostsByContestId(contestId)
+        return WeeklyContestDetailResponseDto.from(postsCount, top7Posts)
     }
 
     @Transactional(readOnly = true)

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
@@ -35,7 +35,8 @@ class WeeklyContestService(
 
     @Transactional(readOnly = true)
     fun getWeeklyContestList(): WeeklyContestListResponseDto {
-        val weeklyContestList: List<WeeklyContestEntity> = weeklyContestAdapter.getAllWeeklyContest()
+        // 1차 투표가 끝난 주간 콘테스트들만 조회
+        val weeklyContestList: List<WeeklyContestEntity> = weeklyContestAdapter.getEndedWeeklyContests()
         return WeeklyContestListResponseDto.from(weeklyContestList)
     }
 

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
@@ -39,7 +39,18 @@ class WeeklyContestService(
     fun getWeeklyContestList(): WeeklyContestListResponseDto {
         // 1차 투표가 끝난 주간 콘테스트들만 조회
         val weeklyContestList: List<WeeklyContestEntity> = weeklyContestAdapter.getEndedWeeklyContests()
-        return WeeklyContestListResponseDto.from(weeklyContestList)
+        return weeklyContestList.map { contest ->
+            val firstPrizePost = weeklyContestFinalAdapter.getFirstPrizePostByContestId(contest.id!!)
+                ?: throw SoonganException(
+                    StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST_POST,
+                    "해당 콘테스트의 1등 게시글이 존재하지 않습니다."
+                )
+
+            WeeklyContestListResponseDto.WeeklyContestDto.from(
+                entity = contest,
+                thumbnailImageUrl = firstPrizePost.weeklyContestPost.imageUrl
+            )
+        }.let { WeeklyContestListResponseDto(it) }
     }
 
     @Transactional(readOnly = true)

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestAdapter.kt
@@ -8,8 +8,8 @@ class WeeklyContestAdapter (
     private val weeklyContestRepository: WeeklyContestRepository
 ){
 
-    fun getAllWeeklyContest(): List<WeeklyContestEntity> {
-        return weeklyContestRepository.findAll()
+    fun getEndedWeeklyContests(now: LocalDateTime = LocalDateTime.now()): List<WeeklyContestEntity> {
+        return weeklyContestRepository.findEndedContests(now)
     }
 
     fun getWeeklyContest(round: Int): WeeklyContestEntity? {

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestEntity.kt
@@ -43,12 +43,6 @@ data class WeeklyContestEntity(
     @Column(name = "end_at", nullable = false)
     val endAt: LocalDateTime = LocalDateTime.MIN,
 
-    @Column(name = "vote_start_at", nullable = false)
-    val voteStartAt: LocalDateTime = LocalDateTime.MIN,
-
-    @Column(name = "vote_end_at", nullable = false)
-    val voteEndAt: LocalDateTime = LocalDateTime.MIN,
-
     @Column(name = "announced_at", nullable = false)
     val announcedAt: LocalDateTime = LocalDateTime.MIN
 ) {

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestRepository.kt
@@ -7,6 +7,9 @@ import java.time.LocalDateTime
 interface WeeklyContestRepository: JpaRepository<WeeklyContestEntity, Long> {
     fun findByRound(round: Int): WeeklyContestEntity?
 
+    @Query("SELECT wc FROM WeeklyContestEntity wc WHERE wc.endAt <= :now")
+    fun findEndedContests(now: LocalDateTime): List<WeeklyContestEntity>
+
     @Query("SELECT wc FROM WeeklyContestEntity wc WHERE wc.startAt <= :now AND wc.endAt > :now")
     fun findInProgressWeeklyContest(now: LocalDateTime): WeeklyContestEntity?
 

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalAdapter.kt
@@ -9,4 +9,8 @@ class WeeklyContestFinalAdapter(
     fun getFinalPostsByContestId(contestId: Long): List<WeeklyContestFinalEntity> {
         return weeklyContestFinRepository.findAllByWeeklyContestId(contestId)
     }
+
+    fun getFirstPrizePostByContestId(contestId: Long): WeeklyContestFinalEntity? {
+        return weeklyContestFinRepository.findFirstPrizePostByContestId(contestId)
+    }
 }

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalAdapter.kt
@@ -1,0 +1,12 @@
+package com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal
+
+import org.springframework.stereotype.Component
+
+@Component
+class WeeklyContestFinalAdapter(
+    private val weeklyContestFinRepository: WeeklyContestFinalRepository
+) {
+    fun getFinalPostsByContestId(contestId: Long): List<WeeklyContestFinalEntity> {
+        return weeklyContestFinRepository.findAllByWeeklyContestId(contestId)
+    }
+}

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalEntity.kt
@@ -40,8 +40,8 @@ data class WeeklyContestFinalEntity(
     @JoinColumn(name = "weekly_contest_post_id")
     val weeklyContestPost: WeeklyContestPostEntity,
 
-    @Column(name = "rank")
-    val ranking: Int,
+    @Column(name = "ranking")
+    val ranking: Int?,
 
     @Column(name = "score")
     val score: Int

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalEntity.kt
@@ -44,7 +44,7 @@ data class WeeklyContestFinalEntity(
     val ranking: Int,
 
     @Column(name = "score")
-    val score: BigDecimal
+    val score: Int
 ) {
 
     @CreatedDate

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalEntity.kt
@@ -41,7 +41,7 @@ data class WeeklyContestFinalEntity(
     val weeklyContestPost: WeeklyContestPostEntity,
 
     @Column(name = "ranking")
-    val ranking: Int?,
+    val ranking: Int,
 
     @Column(name = "score")
     val score: Int

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
@@ -1,8 +1,12 @@
 package com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface WeeklyContestFinalRepository: JpaRepository<WeeklyContestFinalEntity, Long> {
 
     fun findAllByWeeklyContestId(contestId: Long): List<WeeklyContestFinalEntity>
+
+    @Query("SELECT wcf FROM WeeklyContestFinalEntity wcf WHERE wcf.weeklyContest.id = :contestId ORDER BY wcf.ranking ASC LIMIT 1")
+    fun findFirstPrizePostByContestId(contestId: Long): WeeklyContestFinalEntity?
 }

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
@@ -3,4 +3,6 @@ package com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface WeeklyContestFinalRepository: JpaRepository<WeeklyContestFinalEntity, Long> {
+
+    fun findAllByWeeklyContestId(contestId: Long): List<WeeklyContestFinalEntity>
 }

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
@@ -95,4 +95,9 @@ class WeeklyContestPostAdapter(
     fun deleteWeeklyContestPost(postId: Long) {
         weeklyContestPostRepository.deleteById(postId)
     }
+
+    @Transactional(readOnly = true)
+    fun countByWeeklyContestId(contestId: Long): Int {
+        return weeklyContestPostRepository.countByWeeklyContestId(contestId)
+    }
 }

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostEntity.kt
@@ -46,9 +46,6 @@ data class WeeklyContestPostEntity(
     @Column(name = "image_url", nullable = false)
     val imageUrl: String = "",
 
-    @Column(name = "ranking", nullable = false)
-    val ranking: Int = 0,
-
     @Column(name = "like_count")
     val likeCount: Int = 0,
 

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
@@ -42,4 +42,6 @@ interface WeeklyContestPostRepository : JpaRepository<WeeklyContestPostEntity, L
         member: MemberEntity,
         weeklyContestEntity: WeeklyContestEntity
     ): List<WeeklyContestPostEntity>
+
+    fun countByWeeklyContestId(weeklyContestId: Long): Int
 }

--- a/libs/soongan-persistence/src/main/resources/sql/ddl/005-weekly_contest.sql
+++ b/libs/soongan-persistence/src/main/resources/sql/ddl/005-weekly_contest.sql
@@ -6,8 +6,6 @@ create table weekly_contest
     max_post_allowed int          not null,
     start_at         datetime     not null,
     end_at           datetime     not null,
-    vote_start_at    datetime     not null,
-    vote_end_at      datetime     not null,
     announced_at     datetime     not null,
     created_at       datetime     null,
     updated_at       datetime     null

--- a/libs/soongan-persistence/src/main/resources/sql/ddl/006-weekly_contest_final.sql
+++ b/libs/soongan-persistence/src/main/resources/sql/ddl/006-weekly_contest_final.sql
@@ -1,12 +1,12 @@
 create table weekly_contest_final
 (
-    id                  bigint primary key auto_increment,
-    weekly_contest_id   bigint        not null,
-    weekly_contest_post bigint        not null,
-    ranking             int           null,
-    score               decimal(4, 2) null,
-    created_at          datetime      null,
-    updated_at          datetime      null
+    id                      bigint primary key auto_increment,
+    weekly_contest_id       bigint        not null,
+    weekly_contest_post_id  bigint        not null,
+    ranking                 int           null,
+    score                   int           null,
+    created_at              datetime      null,
+    updated_at              datetime      null
 );
 
 create index weekly_contest_final_idx_weekly_contest_id_ranking on weekly_contest_final (weekly_contest_id, ranking);

--- a/libs/soongan-persistence/src/main/resources/sql/ddl/007-weekly_contest_post.sql
+++ b/libs/soongan-persistence/src/main/resources/sql/ddl/007-weekly_contest_post.sql
@@ -5,7 +5,6 @@ create table weekly_contest_post
     member_id         bigint       not null,
     image_url         varchar(1024) not null,
     title             varchar(30) not null,
-    ranking           int          not null,
     like_count        int default 0,
     comment_count     int default 0,
     is_blind          boolean default false,
@@ -13,5 +12,5 @@ create table weekly_contest_post
     updated_at        datetime     null
 );
 
-create index weekly_contest_post_idx_weekly_contest_id_ranking on weekly_contest_post (weekly_contest_id, ranking);
+create index weekly_contest_post_idx_weekly_contest_id on weekly_contest_post (weekly_contest_id);
 create index weekly_contest_post_idx_member_id on weekly_contest_post (member_id);

--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/constant/Uri.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/constant/Uri.kt
@@ -26,6 +26,7 @@ object Uri {
 
     const val WEEKLY = "/weekly"
     const val CONTESTS = "/contests"
+    const val HISTORIES = "/histories"
     const val POSTS = "/posts"
     const val COMMENTS = "/comments"
     const val REPLIES = "/replies"

--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/exception/StatusCode.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/exception/StatusCode.kt
@@ -42,7 +42,7 @@ enum class StatusCode(val code: Int, val message: String) {
     SOONGAN_API_INVALID_CONTEST_TYPE(1102, "Invalid Contest Type"),
     SOONGAN_API_WEEKLY_CONTEST_POST_REGISTER_LIMIT_EXCEEDED(1103, "Weekly Contest Post Register Limit Exceeded"),
     SOONGAN_API_NOT_OWNER_WEEKLY_CONTEST_POST(1104, "Not Owner Weekly Contest Post"),
-    SOONGAN_API_CANNOT_UPDATE_POST_AFTER_STARTING_VOTE(1105, "Cannot Update Post After Starting Vote"),
+    SOONGAN_API_CANNOT_UPDATE_POST_AFTER_VOTE_END(1105, "Cannot Update Post After End Vote"),
 
     // 1200 ~ 1299 Like Status Code
     SOONGAN_API_DUPLICATED_LIKE(1200, "Duplicated Like"),


### PR DESCRIPTION
# 관련이슈

#180 

# Base on Branch

- develop

# 변경점

- 역대 콘테스트 목록 조회 api에서 endAt이 현재 이전인 것들만 조회하도록 수정 (원래는 상관 없이 모두 조회)
- 특정 역대 콘테스트 상세 조회 api 추가
- WeeklyContestFinalEntity에 score를 피그마 상에서 그냥 투표 수를 나타내는 정수로 표현하는 것 같아서 Int로 수정
- WeeklyContestPost의 ranking 필드 불필요하다고 판단하여 제거

# 논의할 점

- endAt이 끝난 시점에 Final 데이터 7개를 생성해야 하는데, 어떻게 할지 설계가 필요함

# Example/Screenshot (if any)

- 

# TODO

- 엔티티 수정한 대로 DB 스키마 수정
  - WeeklyContestPost의 ranking 제거
  - WeeklyContest의 voteStartAt, voteEndAt 제거

