### PR TITLE
로그인시 Provider ID도 검사하도록 수정

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/admin/member/dto/response/MemberAdminResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/admin/member/dto/response/MemberAdminResponseDto.kt
@@ -40,7 +40,7 @@ data class MemberAdminResponseDto(
     companion object {
         fun from(memberEntity: MemberEntity): MemberAdminResponseDto {
             return MemberAdminResponseDto(
-                id = memberEntity.id!!,
+                id = memberEntity.id,
                 email = memberEntity.email,
                 provider = memberEntity.provider,
                 nickname = memberEntity.nickname,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/admin/report/ReportAdminController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/admin/report/ReportAdminController.kt
@@ -21,7 +21,6 @@ class ReportAdminController {
     )
     @GetMapping
     fun getAll(@ModelAttribute @Valid requestDto: GetReportsAdminRequestDto): List<Int> {
-        println(requestDto)
         return listOf(1, 2, 3)
     }
 }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/awards/dto/response/AwardsDetailResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/awards/dto/response/AwardsDetailResponseDto.kt
@@ -22,7 +22,7 @@ data class AwardsDetailResponseDto(
         companion object {
             fun from(weeklyContestFinalEntity: WeeklyContestFinalEntity): FirstPrizePostResponseDto {
                 return FirstPrizePostResponseDto(
-                    postId = weeklyContestFinalEntity.weeklyContestPost.id!!,
+                    postId = weeklyContestFinalEntity.weeklyContestPost.id,
                     title = weeklyContestFinalEntity.weeklyContestPost.title,
                     imageUrl = weeklyContestFinalEntity.weeklyContestPost.imageUrl,
                     nickname = weeklyContestFinalEntity.weeklyContestPost.member.nickname,
@@ -57,7 +57,7 @@ data class AwardsDetailResponseDto(
                 }
 
                 return TopPostResponseDto(
-                    postId = weeklyContestFinalEntity.weeklyContestPost.id!!,
+                    postId = weeklyContestFinalEntity.weeklyContestPost.id,
                     imageUrl = post.imageUrl,
                     nickname = post.member.nickname,
                     ranking = weeklyContestFinalEntity.ranking,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/comment/dto/response/GetCommentResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/comment/dto/response/GetCommentResponseDto.kt
@@ -27,7 +27,7 @@ data class GetCommentResponseDto(
                 comments = commentSlice.content.map {
                     CommentDto(
                         commentId = it.id!!,
-                        memberId = it.member.id!!,
+                        memberId = it.member.id,
                         memberNickname = it.member.nickname ?: "",
                         commentText = it.commentText,
                         parentCommentID = it.parentComment?.id,
@@ -56,7 +56,7 @@ data class GetCommentReplyResponseDto(
                 comments = commentSlice.content.map {
                     CommentDto(
                         commentId = it.id!!,
-                        memberId = it.member.id!!,
+                        memberId = it.member.id,
                         memberNickname = it.member.nickname ?: "",
                         commentText = it.commentText,
                         parentCommentID = it.parentComment?.id,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/report/dto/response/ReportSaveResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/report/dto/response/ReportSaveResponseDto.kt
@@ -34,8 +34,8 @@ data class ReportSaveResponseDto(
         fun from(reportEntity: ReportEntity, reportHistories: List<ReportEntity>): ReportSaveResponseDto {
             return ReportSaveResponseDto(
                 id = reportEntity.id!!,
-                reportMemberId = reportEntity.reportMember.id!!,
-                targetMemberId = reportEntity.targetMember.id!!,
+                reportMemberId = reportEntity.reportMember.id,
+                targetMemberId = reportEntity.targetMember.id,
                 targetId = reportEntity.targetId,
                 targetType = reportEntity.targetType.name,
                 reportType = reportEntity.reportType,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
@@ -42,6 +42,11 @@ class AuthService(
         if (member != null) {
             this.checkMember(member)
         } else {
+            val sameEmailMember = memberAdapter.getByEmail(oauthValidateResult.email)
+            if (sameEmailMember != null) {
+                throw SoonganException(StatusCode.SOONGAN_API_DIFFERENT_PROVIDER, "해당 이메일은 ${sameEmailMember.provider}로 가입된 회원입니다.")
+            }
+
             // 회원이 존재하지 않는 경우, 새로 생성
             member = memberAdapter.save(
                 MemberEntity(

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
@@ -33,16 +33,17 @@ class AuthService(
     fun login(userAgent: UserAgentEnum, loginDto: LoginRequestDto): LoginResponseDto {
         val provider = loginDto.provider
         val idToken = loginDto.idToken
-        val memberEmail = when (provider) {
+        val oauthValidateResult = when (provider) {
             ProviderEnum.GOOGLE -> googleOAuth2Validator.validateTokenAndGetEmail(idToken, userAgent)
             ProviderEnum.KAKAO -> kakaoOAuth2Validator.validateTokenAndGetEmail(idToken)
             ProviderEnum.APPLE -> appleOAuth2Validator.validateTokenAndGetEmail(idToken)
         }
-        val member = memberAdapter.getByEmail(memberEmail)
+        val member = memberAdapter.getByEmail(oauthValidateResult.email)
             ?: memberAdapter.save(
                 MemberEntity(
-                    email = memberEmail,
+                    email = oauthValidateResult.email,
                     provider = provider,
+                    providerId = oauthValidateResult.providerId,
                 )
             )
 

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
@@ -38,12 +38,8 @@ class AuthService(
             ProviderEnum.KAKAO -> kakaoOAuth2Validator.validateTokenAndGetEmail(idToken)
             ProviderEnum.APPLE -> appleOAuth2Validator.validateTokenAndGetEmail(idToken)
         }
-        var member = memberAdapter.getByEmail(oauthValidateResult.email)
+        var member = memberAdapter.getByProviderAndProviderId(provider = provider, providerId = oauthValidateResult.providerId)
         if (member != null) {
-            if (member.provider != provider) {
-                throw SoonganException(StatusCode.SOONGAN_API_DIFFERENT_PROVIDER, "해당 회원은 ${member.provider}로 가입된 회원입니다.")
-            }
-
             this.checkMember(member)
         } else {
             // 회원이 존재하지 않는 경우, 새로 생성

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
@@ -38,20 +38,23 @@ class AuthService(
             ProviderEnum.KAKAO -> kakaoOAuth2Validator.validateTokenAndGetEmail(idToken)
             ProviderEnum.APPLE -> appleOAuth2Validator.validateTokenAndGetEmail(idToken)
         }
-        val member = memberAdapter.getByEmail(oauthValidateResult.email)
-            ?: memberAdapter.save(
+        var member = memberAdapter.getByEmail(oauthValidateResult.email)
+        if (member != null) {
+            if (member.provider != provider) {
+                throw SoonganException(StatusCode.SOONGAN_API_DIFFERENT_PROVIDER, "해당 회원은 ${member.provider}로 가입된 회원입니다.")
+            }
+
+            this.checkMember(member)
+        } else {
+            // 회원이 존재하지 않는 경우, 새로 생성
+            member = memberAdapter.save(
                 MemberEntity(
                     email = oauthValidateResult.email,
                     provider = provider,
-                    providerId = oauthValidateResult.providerId,
+                    providerId =  oauthValidateResult.providerId,
                 )
             )
-
-        if (member.provider != provider) {
-            throw SoonganException(StatusCode.SOONGAN_API_DIFFERENT_PROVIDER, "해당 이메일은 ${member.provider}로 가입된 회원입니다.")
         }
-
-        this.checkMember(member)
 
         fcmTokenAdapter.findByToken(loginDto.fcmToken)?.let { foundFcmToken ->
             if (foundFcmToken.member == null || foundFcmToken.member!!.id != member.id) {

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/AppleOAuth2Validator.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/AppleOAuth2Validator.kt
@@ -5,6 +5,7 @@ import com.nimbusds.jose.crypto.RSASSAVerifier
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.util.Base64URL
 import com.nimbusds.jwt.SignedJWT
+import com.soongan.soonganbackend.soonganapi.service.auth.validator.dto.OAuth2ValidateResult
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
 import org.springframework.stereotype.Service
@@ -16,7 +17,7 @@ class AppleOAuth2Validator(
     private val restTemplate: RestTemplate
 ) {
 
-    fun validateTokenAndGetEmail(idToken: String): String {
+    fun validateTokenAndGetEmail(idToken: String): OAuth2ValidateResult {
         val applePublicKeysUrl = "https://appleid.apple.com/auth/keys"
         val applePublicKeySets = restTemplate.getForObject<Map<*, *>>(
             applePublicKeysUrl
@@ -44,6 +45,12 @@ class AppleOAuth2Validator(
         }
 
         val claims = signedJWT.jwtClaimsSet
-        return claims.getStringClaim("email")
+        return OAuth2ValidateResult(
+            providerId = claims.subject,
+            email = claims.getStringClaim("email") ?: throw SoonganException(
+                StatusCode.INVALID_OAUTH2_ID_TOKEN,
+                "Apple 계정에 이메일 정보가 없습니다."
+            )
+        )
     }
 }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/AppleOAuth2Validator.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/AppleOAuth2Validator.kt
@@ -47,10 +47,8 @@ class AppleOAuth2Validator(
         val claims = signedJWT.jwtClaimsSet
         return OAuth2ValidateResult(
             providerId = claims.subject,
-            email = claims.getStringClaim("email") ?: throw SoonganException(
-                StatusCode.INVALID_OAUTH2_ID_TOKEN,
-                "Apple 계정에 이메일 정보가 없습니다."
-            )
+            // 애플은 email을 오직 1회만 제공하므로, 그 때 저장을 하지 못한 경우를 대비해 기본값 설정
+            email = claims.getStringClaim("email") ?: "${claims.subject}@apple.soongan.site"
         )
     }
 }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/GoogleOAuth2Validator.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/GoogleOAuth2Validator.kt
@@ -3,6 +3,7 @@ package com.soongan.soonganbackend.soonganapi.service.auth.validator
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
+import com.soongan.soonganbackend.soonganapi.service.auth.validator.dto.OAuth2ValidateResult
 import com.soongan.soonganbackend.soongansupport.domain.UserAgentEnum
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
@@ -14,7 +15,7 @@ class GoogleOAuth2Validator(
     private val env: Environment
 ) {
 
-    fun validateTokenAndGetEmail(idToken: String, userAgent: UserAgentEnum): String {
+    fun validateTokenAndGetEmail(idToken: String, userAgent: UserAgentEnum): OAuth2ValidateResult {
         val clientId = when (userAgent) {
             UserAgentEnum.ANDROID -> env.getProperty("oauth2.android.google.client-id")
             UserAgentEnum.IOS -> env.getProperty("oauth2.ios.google.client-id")
@@ -31,8 +32,10 @@ class GoogleOAuth2Validator(
                     "Google IdToken이 유효하지 않아 회원 정보를 가져올 수 없습니다."
                 )
 
-            val email = verifiedIdToken.payload.email
-            return email as String
+            return OAuth2ValidateResult(
+                providerId = verifiedIdToken.payload.subject,
+                email = verifiedIdToken.payload.email
+            )
         } catch (e: IllegalArgumentException) {  // 토큰 자체 형식이 맞지 않아 해독 도중 에러가 발생한 경우
             throw SoonganException(StatusCode.INVALID_OAUTH2_ID_TOKEN, "잘못된 Google IdToken 형식으로 회원 정보를 가져올 수 없습니다.")
         }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/KakaoOAuth2Validator.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/KakaoOAuth2Validator.kt
@@ -1,6 +1,7 @@
 package com.soongan.soonganbackend.soonganapi.service.auth.validator
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.soongan.soonganbackend.soonganapi.service.auth.validator.dto.OAuth2ValidateResult
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
 import org.springframework.http.HttpEntity
@@ -15,7 +16,7 @@ class KakaoOAuth2Validator(
     private val restTemplate: RestTemplate
 ) {
 
-    fun validateTokenAndGetEmail(idToken: String): String {
+    fun validateTokenAndGetEmail(idToken: String): OAuth2ValidateResult {
         val url = "https://kapi.kakao.com/v2/user/me"
 
         val headers = HttpHeaders().apply {
@@ -30,11 +31,13 @@ class KakaoOAuth2Validator(
                 KakaoUserResponse::class.java
             )
 
-            response.body?.kakaoAccount?.email
-                ?: throw SoonganException(
+            OAuth2ValidateResult(
+                providerId = response.body?.id.toString(),
+                email = response.body?.kakaoAccount?.email ?: throw SoonganException(
                     StatusCode.INVALID_OAUTH2_ID_TOKEN,
-                    "카카오 이메일 정보를 찾을 수 없습니다."
+                    "카카오 계정에 이메일 정보가 없습니다."
                 )
+            )
         } catch (e: RestClientException) {
             throw SoonganException(
                 StatusCode.INVALID_OAUTH2_ID_TOKEN,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/dto/OAuth2ValidateResult.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/validator/dto/OAuth2ValidateResult.kt
@@ -1,0 +1,6 @@
+package com.soongan.soonganbackend.soonganapi.service.auth.validator.dto
+
+data class OAuth2ValidateResult(
+    val providerId: String,
+    val email: String,
+)

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/comment/CommentService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/comment/CommentService.kt
@@ -56,7 +56,7 @@ class CommentService(
             )
         )
 
-        val fcmTokens = fcmTokenAdapter.findAllByMemberId(weeklyContestPost.member.id!!)
+        val fcmTokens = fcmTokenAdapter.findAllByMemberId(weeklyContestPost.member.id)
         fcmTokens.map { it.token }.let { tokens ->
             if (tokens.isNotEmpty()) {
                 val message = Message.createCommentMessage(tokens, request.postId)

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberAdminService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberAdminService.kt
@@ -32,6 +32,6 @@ class MemberAdminService(
 
         val member = optionalMember.get()
         if (member.withdrawalAt == null) throw SoonganException(StatusCode.BAD_REQUEST, "해당 유저는 탈퇴한 회원이 아닙니다.")
-        memberAdapter.deleteOne(member.id!!)
+        memberAdapter.deleteOne(member.id)
     }
 }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
@@ -50,7 +50,7 @@ class MemberService(
 
         val oldProfileImageUrl = loginMember.profileImageUrl
         val updatedProfileImageUrl = request.profileImage?.let {
-            gcpStorageService.uploadProfileImage(it, loginMember.id!!)
+            gcpStorageService.uploadProfileImage(it, loginMember.id)
         }
 
         val updatedMember = loginMember.copy(

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContestPost/WeeklyContestService.kt
@@ -47,7 +47,7 @@ class WeeklyContestService(
 
         loginMember?.let {
             val isLiked: Boolean = likeAdapter.existsByPostIdAndContestTypeAndMember(postId, ContestTypeEnum.WEEKLY, loginMember)
-            return WeeklyContestPostResponseDto.from(loginMember.id!!, weeklyContestPost, isLiked)
+            return WeeklyContestPostResponseDto.from(loginMember.id, weeklyContestPost, isLiked)
         }
 
         return WeeklyContestPostResponseDto.from(weeklyContestPost =  weeklyContestPost)
@@ -133,7 +133,7 @@ class WeeklyContestService(
 
         val imageUrl = gcpStorageService.uploadContestImage(
             request.imageFile,
-            loginMember.id!!,
+            loginMember.id,
             ContestTypeEnum.WEEKLY,
             weeklyContest.round
         )

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/auth/AuthServiceTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/auth/AuthServiceTest.kt
@@ -6,6 +6,7 @@ import com.soongan.soonganbackend.soonganapi.service.auth.AuthService
 import com.soongan.soonganbackend.soonganapi.service.auth.validator.AppleOAuth2Validator
 import com.soongan.soonganbackend.soonganapi.service.auth.validator.GoogleOAuth2Validator
 import com.soongan.soonganbackend.soonganapi.service.auth.validator.KakaoOAuth2Validator
+import com.soongan.soonganbackend.soonganapi.service.auth.validator.dto.OAuth2ValidateResult
 import com.soongan.soonganbackend.soonganpersistence.storage.fcm.FcmTokenAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.fcm.FcmTokenEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberAdapter
@@ -72,7 +73,10 @@ class AuthServiceTest {
         )
 
         // mock
-        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns email
+        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns OAuth2ValidateResult(
+            providerId = "provider-id",
+            email = email
+        )
         every { memberAdapter.getByEmail(email) } returns null
         every { memberAdapter.save(any()) } returns member
         every { fcmTokenAdapter.findByToken(loginDto.fcmToken) } returns fcmToken
@@ -112,7 +116,10 @@ class AuthServiceTest {
         )
 
         // mock
-        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns email
+        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns OAuth2ValidateResult(
+            providerId = "provider-id",
+            email = email
+        )
         every { memberAdapter.getByEmail(email) } returns member
         every { fcmTokenAdapter.findByToken(loginDto.fcmToken) } returns fcmToken
         every { fcmTokenAdapter.save(any()) } returns fcmToken
@@ -146,7 +153,10 @@ class AuthServiceTest {
         )
 
         // mock
-        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns email
+        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns OAuth2ValidateResult(
+            providerId = "provider-id",
+            email = email
+        )
         every { memberAdapter.getByEmail(email) } returns member
 
         // when & then
@@ -170,7 +180,10 @@ class AuthServiceTest {
         )
 
         // mock
-        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns email
+        every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns OAuth2ValidateResult(
+            providerId = "provider-id",
+            email = email
+        )
         every { memberAdapter.getByEmail(email) } returns member
         every { fcmTokenAdapter.findByToken(loginDto.fcmToken) } returns null
 

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/auth/AuthServiceTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/auth/AuthServiceTest.kt
@@ -74,9 +74,10 @@ class AuthServiceTest {
 
         // mock
         every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns OAuth2ValidateResult(
-            providerId = "",
+            providerId = "provider-id",
             email = email
         )
+        every { memberAdapter.getByProviderAndProviderId(provider = ProviderEnum.GOOGLE, providerId = "provider-id") } returns null
         every { memberAdapter.getByEmail(email) } returns null
         every { memberAdapter.save(any()) } returns member
         every { fcmTokenAdapter.findByToken(loginDto.fcmToken) } returns fcmToken
@@ -120,7 +121,7 @@ class AuthServiceTest {
             providerId = "provider-id",
             email = email
         )
-        every { memberAdapter.getByEmail(email) } returns member
+        every { memberAdapter.getByProviderAndProviderId(provider = ProviderEnum.GOOGLE, providerId =  "provider-id") } returns member
         every { fcmTokenAdapter.findByToken(loginDto.fcmToken) } returns fcmToken
         every { fcmTokenAdapter.save(any()) } returns fcmToken
         every { jwtHandler.issueTokens(email) } returns Pair("access-token", "refresh-token")
@@ -157,7 +158,7 @@ class AuthServiceTest {
             providerId = "provider-id",
             email = email
         )
-        every { memberAdapter.getByEmail(email) } returns member
+        every { memberAdapter.getByProviderAndProviderId(provider = ProviderEnum.GOOGLE, providerId = "provider-id") } returns member
 
         // when & then
         assertThatThrownBy { authService.login(UserAgentEnum.ANDROID, loginDto) }
@@ -184,7 +185,7 @@ class AuthServiceTest {
             providerId = "provider-id",
             email = email
         )
-        every { memberAdapter.getByEmail(email) } returns member
+        every { memberAdapter.getByProviderAndProviderId(provider = ProviderEnum.GOOGLE, providerId = "provider-id") } returns member
         every { fcmTokenAdapter.findByToken(loginDto.fcmToken) } returns null
 
         // when & then

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/auth/AuthServiceTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/auth/AuthServiceTest.kt
@@ -63,7 +63,7 @@ class AuthServiceTest {
         )
         val member = MemberEntity(
             email = email,
-            provider = ProviderEnum.GOOGLE
+            provider = ProviderEnum.GOOGLE,
         )
         val fcmToken = FcmTokenEntity(
             token = "fcm-token",
@@ -74,7 +74,7 @@ class AuthServiceTest {
 
         // mock
         every { googleOAuth2Validator.validateTokenAndGetEmail(any(), any()) } returns OAuth2ValidateResult(
-            providerId = "provider-id",
+            providerId = "",
             email = email
         )
         every { memberAdapter.getByEmail(email) } returns null

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberAdapter.kt
@@ -1,5 +1,6 @@
 package com.soongan.soonganbackend.soonganpersistence.storage.member
 
+import com.soongan.soonganbackend.soongansupport.domain.ProviderEnum
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.util.Optional
@@ -16,6 +17,11 @@ class MemberAdapter (
     @Transactional(readOnly = true)
     fun getByEmail(email: String): MemberEntity? {
         return memberRepository.findByEmail(email)
+    }
+
+    @Transactional(readOnly = true)
+    fun getByProviderAndProviderId(provider: ProviderEnum, providerId: String): MemberEntity? {
+        return memberRepository.findByProviderAndProviderId(provider, providerId)
     }
 
     @Transactional(readOnly = true)

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberEntity.kt
@@ -43,7 +43,7 @@ data class MemberEntity(
     val provider: ProviderEnum = ProviderEnum.GOOGLE,
 
     @Column(name = "provider_id")
-    val providerId: String,
+    val providerId: String = "",
 
     @Column(name = "withdrawal_at")
     val withdrawalAt: LocalDateTime? = null,

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberEntity.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberEntity.kt
@@ -42,6 +42,9 @@ data class MemberEntity(
     @Enumerated(EnumType.STRING)
     val provider: ProviderEnum = ProviderEnum.GOOGLE,
 
+    @Column(name = "provider_id")
+    val providerId: String,
+
     @Column(name = "withdrawal_at")
     val withdrawalAt: LocalDateTime? = null,
 

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberRepository.kt
@@ -1,9 +1,11 @@
 package com.soongan.soonganbackend.soonganpersistence.storage.member
 
+import com.soongan.soonganbackend.soongansupport.domain.ProviderEnum
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository: JpaRepository<MemberEntity, Long> {
     fun findByEmail(email: String): MemberEntity?
+    fun findByProviderAndProviderId(provider: ProviderEnum, providerId: String): MemberEntity?
     fun findByNickname(nickname: String): MemberEntity?
 
     fun findAllByEmail(email: String): List<MemberEntity>

--- a/libs/soongan-persistence/src/main/resources/sql/ddl/003-member.sql
+++ b/libs/soongan-persistence/src/main/resources/sql/ddl/003-member.sql
@@ -7,8 +7,11 @@ create table member
     self_introduction text         null,
     profile_image_url varchar(255) null,
     provider          varchar(20)  not null,
+    provider_id       varchar(255) not null,
     withdrawal_at     datetime     null,
     ban_until         datetime     null,
     created_at        datetime     null,
     updated_at        datetime     null
 );
+
+create unique index idx_member_email_provider on member (email, provider);

--- a/libs/soongan-persistence/src/main/resources/sql/ddl/003-member.sql
+++ b/libs/soongan-persistence/src/main/resources/sql/ddl/003-member.sql
@@ -14,5 +14,5 @@ create table member
     updated_at        datetime     null
 );
 
-create index idx_member_email on member (email);
+create unique index idx_member_email on member (email);
 create unique index idx_member_provider_provider_id on member (provider, provider_id);

--- a/libs/soongan-persistence/src/main/resources/sql/ddl/003-member.sql
+++ b/libs/soongan-persistence/src/main/resources/sql/ddl/003-member.sql
@@ -14,4 +14,5 @@ create table member
     updated_at        datetime     null
 );
 
-create unique index idx_member_email_provider on member (email, provider);
+create index idx_member_email on member (email);
+create unique index idx_member_provider_provider_id on member (provider, provider_id);


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- apple의 경우 이메일 정보는 같은 OAuth2 클라이언트에게 오직 한번만 내려줌
- 그래서 계정마다 고유한 providerId로 구분할 필요가 있음 => 구현

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     
- [ ] DB 스키마에 provider_id 추가


