### PR TITLE
fix: URL에 number로 받는 것과 문자열로 받는 것 구분

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/admin/member/MemberAdminController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/admin/member/MemberAdminController.kt
@@ -33,7 +33,7 @@ class MemberAdminController(
         summary = "탈퇴 회원 재가입 제한 해제",
         description = "탈퇴한 회원 데이터를 완전히 삭제하여 재가입 제한을 해제합니다. 단, 회원의 모든 데이터가 삭제되며, 다시 가입해야 합니다."
     )
-    @DeleteMapping("/{memberId}")
+    @DeleteMapping("/{memberId:[0-9]+}")
     fun deleteOne(@PathVariable memberId: Long): Unit {
         memberAdminService.deleteOne(memberId)
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/awards/AwardsController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/awards/AwardsController.kt
@@ -31,7 +31,7 @@ class AwardsController(
         summary = "특정 역대 주간 콘테스트 조회",
         description = "특정 역대 주간 콘테스트를 상세 조회합니다. 해당 콘테스트의 1차 투표 상위 7개 게시글을 함께 조회합니다."
     )
-    @GetMapping("/{contestId}")
+    @GetMapping("/{contestId:[0-9]+}")
     fun getAwardsDetail(@PathVariable contestId: Long): AwardsDetailResponseDto {
         return awardsService.getAwardsDetail(contestId)
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/notification/NotificationController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/notification/NotificationController.kt
@@ -49,7 +49,7 @@ class NotificationController(
         return notificationService.getNotifications(loginMember, type)
     }
 
-    @PostMapping("/{notificationId}/read")
+    @PostMapping("/{notificationId:[0-9]+}/read")
     @Operation(
         summary = "알림 읽음 처리 Api",
         description = "알림을 읽음 처리합니다.",
@@ -60,7 +60,7 @@ class NotificationController(
     }
 
     // TODO: 소명 완료 시 삭제?
-    @DeleteMapping("/{notificationId}")
+    @DeleteMapping("/{notificationId:[0-9]+}")
     @Operation(
         summary = "알림 삭제 Api",
         description = "알림을 삭제합니다.",

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/WeeklyContestController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/WeeklyContestController.kt
@@ -44,7 +44,7 @@ class WeeklyContestController (
         description = "주간 콘테스트 게시글을 단일 조회합니다.",
         security = [SecurityRequirement(name = "JWT")]
     )
-    @GetMapping(Uri.POSTS + "/{postId}")
+    @GetMapping(Uri.POSTS + "/{postId:[0-9]+}")
     fun getWeeklyContestPost(
         @LoginMember(throwIfUnauthorized = false) loginMember: MemberEntity?,
         @PathVariable postId: Long
@@ -113,7 +113,7 @@ class WeeklyContestController (
         description = "주간 콘테스트 게시글을 수정합니다.",
         security = [SecurityRequirement(name = "JWT")]
     )
-    @PatchMapping(Uri.POSTS + "/{postId}")
+    @PatchMapping(Uri.POSTS + "/{postId:[0-9]+}")
     fun updateWeeklyContestPost(
         @LoginMember loginMember: MemberEntity,
         @PathVariable postId: Long,
@@ -127,7 +127,7 @@ class WeeklyContestController (
         description = "내가 작성한 주간 콘테스트 게시글을 삭제합니다.",
         security = [SecurityRequirement(name = "JWT")]
     )
-    @DeleteMapping(Uri.POSTS + "/{postId}")
+    @DeleteMapping(Uri.POSTS + "/{postId:[0-9]+}")
     fun deleteMyWeeklyContestPost(
         @LoginMember loginMember: MemberEntity,
         @PathVariable postId: Long


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

`/weekly/contests/posts/my-history`와 `/weekly/contests/posts/{postId}`가 구분이 안됐는데 정규식 추가하여 구분

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



