### PR TITLE
다른 회원 정보 조회 api 추가

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/MemberController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/MemberController.kt
@@ -38,7 +38,7 @@ class MemberController(
     @Operation(
         summary = "회원 정보 조회 Api",
         description = "회원 ID로 회원 정보를 조회합니다. 다른 회원의 프로필 정보를 조회할 때 사용합니다.",
-        servers = []
+        security = []
     )
     @GetMapping("{memberId:[0-9]+}")
     fun getMemberInfo(

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/MemberController.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/MemberController.kt
@@ -13,6 +13,7 @@ import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -25,14 +26,27 @@ class MemberController(
 ) {
 
     @Operation(
-        summary = "회원 정보 조회 Api",
+        summary = "로그인한 회원 정보 조회 Api",
         description = "JWT를 읽어 로그인한 회원의 정보를 조회합니다.",
         security = [SecurityRequirement(name = "JWT")]
     )
     @GetMapping
-    fun getUserinfo(@LoginMember loginMember: MemberEntity): MemberInfoResponseDto {
-        return memberService.getMemberInfo(loginMember)
+    fun getLoginMemberinfo(@LoginMember loginMember: MemberEntity): LoginMemberInfoResponseDto {
+        return memberService.getLoginMemberInfo(loginMember)
     }
+
+    @Operation(
+        summary = "회원 정보 조회 Api",
+        description = "회원 ID로 회원 정보를 조회합니다. 다른 회원의 프로필 정보를 조회할 때 사용합니다.",
+        servers = []
+    )
+    @GetMapping("{memberId:[0-9]+}")
+    fun getMemberInfo(
+        @PathVariable("memberId") memberId: Long,
+    ): MemberInfoResponseDto {
+        return memberService.getMemberInfo(memberId)
+    }
+
 
     @Operation(
         summary = "닉네임 중복 확인 Api",

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/LoginMemberInfoResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/LoginMemberInfoResponseDto.kt
@@ -1,12 +1,14 @@
 package com.soongan.soonganbackend.soonganapi.interfaces.member.dto.response
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.soongan.soonganbackend.soonganapi.interfaces.report.dto.response.ReportHistoryResponseDto
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
+import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportEntity
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "회원 정보 응답 DTO")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class MemberInfoResponseDto(
+data class LoginMemberInfoResponseDto(
     @Schema(description = "이메일", required = true)
     val email: String,
 
@@ -21,15 +23,23 @@ data class MemberInfoResponseDto(
 
     @Schema(description = "자기소개")
     val selfIntroduction: String?,
+
+    @Schema(description = "유저가 신고한 내역")
+    val reportHistories: List<ReportHistoryResponseDto>
 ) {
     companion object {
-        fun from(member: MemberEntity): MemberInfoResponseDto {
-            return MemberInfoResponseDto(
+        fun from(member: MemberEntity, reportHistories: List<ReportEntity>): LoginMemberInfoResponseDto {
+            val reportHistoryResponseDtos = reportHistories.map { reportHistory ->
+                ReportHistoryResponseDto.from(reportHistory)
+            }
+
+            return LoginMemberInfoResponseDto(
                 email = member.email,
                 nickname = member.nickname,
                 birthYear = member.birthYear,
                 profileImageUrl = member.profileImageUrl,
                 selfIntroduction = member.selfIntroduction,
+                reportHistories = reportHistoryResponseDtos
             )
         }
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/LoginMemberInfoResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/LoginMemberInfoResponseDto.kt
@@ -6,9 +6,12 @@ import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportEntity
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "회원 정보 응답 DTO")
+@Schema(description = "로그인한 회원 정보 응답 DTO")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class LoginMemberInfoResponseDto(
+    @Schema(description = "회원 ID", required = true)
+    val id: Long,
+
     @Schema(description = "이메일", required = true)
     val email: String,
 
@@ -34,6 +37,7 @@ data class LoginMemberInfoResponseDto(
             }
 
             return LoginMemberInfoResponseDto(
+                id = member.id,
                 email = member.email,
                 nickname = member.nickname,
                 birthYear = member.birthYear,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/MemberInfoResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/member/dto/response/MemberInfoResponseDto.kt
@@ -7,6 +7,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "회원 정보 응답 DTO")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class MemberInfoResponseDto(
+    @Schema(description = "회원 ID", required = true)
+    val id: Long,
+
     @Schema(description = "이메일", required = true)
     val email: String,
 
@@ -25,6 +28,7 @@ data class MemberInfoResponseDto(
     companion object {
         fun from(member: MemberEntity): MemberInfoResponseDto {
             return MemberInfoResponseDto(
+                id = member.id,
                 email = member.email,
                 nickname = member.nickname,
                 birthYear = member.birthYear,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
@@ -17,9 +17,18 @@ class MemberService(
     private val reportAdapter: ReportAdapter,
     private val gcpStorageService: GcpStorageService,
 ) {
-    fun getMemberInfo(loginMember: MemberEntity): MemberInfoResponseDto {
+    fun getLoginMemberInfo(loginMember: MemberEntity): LoginMemberInfoResponseDto {
         val reportHistories = reportAdapter.getReportHistoriesByReportMember(loginMember)
-        return MemberInfoResponseDto.from(loginMember, reportHistories)
+        return LoginMemberInfoResponseDto.from(loginMember, reportHistories)
+    }
+
+    fun getMemberInfo(memberId: Long): MemberInfoResponseDto {
+        val optionalMember = memberAdapter.getById(memberId)
+        if (optionalMember.isEmpty) {
+            throw SoonganException(StatusCode.NOT_FOUND, "해당 ID의 회원이 존재하지 않습니다. memberId: $memberId")
+        }
+
+        return MemberInfoResponseDto.from(optionalMember.get())
     }
 
     @Transactional(readOnly = true)

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/member/MemberService.kt
@@ -23,12 +23,9 @@ class MemberService(
     }
 
     fun getMemberInfo(memberId: Long): MemberInfoResponseDto {
-        val optionalMember = memberAdapter.getById(memberId)
-        if (optionalMember.isEmpty) {
-            throw SoonganException(StatusCode.NOT_FOUND, "해당 ID의 회원이 존재하지 않습니다. memberId: $memberId")
-        }
-
-        return MemberInfoResponseDto.from(optionalMember.get())
+        val member = memberAdapter.getById(memberId)
+            .orElseThrow { SoonganException(StatusCode.NOT_FOUND, "해당 ID의 회원이 존재하지 않습니다. memberId: $memberId") }
+        return MemberInfoResponseDto.from(member)
     }
 
     @Transactional(readOnly = true)

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/member/MemberServiceTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/member/MemberServiceTest.kt
@@ -51,7 +51,7 @@ class MemberServiceTest {
         every { reportAdapter.getReportHistoriesByReportMember(loginMember) } returns emptyList()
 
         // when
-        val result = memberService.getMemberInfo(loginMember)
+        val result = memberService.getLoginMemberInfo(loginMember)
 
         // then
         assertThat(result)

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/member/MemberAdapter.kt
@@ -15,6 +15,11 @@ class MemberAdapter (
     }
 
     @Transactional(readOnly = true)
+    fun getById(id: Long): Optional<MemberEntity> {
+        return memberRepository.findById(id)
+    }
+
+    @Transactional(readOnly = true)
     fun getByEmail(email: String): MemberEntity? {
         return memberRepository.findByEmail(email)
     }
@@ -39,12 +44,6 @@ class MemberAdapter (
     @Transactional(readOnly = true)
     fun getAllByNickname(nickname: String): List<MemberEntity> {
         return memberRepository.findAllByNickname(nickname)
-    }
-
-    // admin용
-    @Transactional(readOnly = true)
-    fun getById(id: Long): Optional<MemberEntity> {
-        return memberRepository.findById(id)
     }
 
     @Transactional

--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/constant/Uri.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/constant/Uri.kt
@@ -59,6 +59,8 @@ object Uri {
         SWAGGER_RESOURCES + "/**",
         V3 + API_DOCS + "/**",
 
+        MEMBERS + "/{memberId:[0-9]+}",
+
         WEEKLY + CONTESTS,
         WEEKLY + CONTESTS + POSTS,
 


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- 기존 로그인 회원 정보 조회 api 외에 memberId로 회원 조회하는 api 추가

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



