### PR TITLE
refactor: 게시글 단일 조회에 정보 추가

### DIFF
--- a/.github/workflows/deploy-api-dev.yml
+++ b/.github/workflows/deploy-api-dev.yml
@@ -25,7 +25,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build Docker image
+      - name: Build & Push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -40,11 +40,60 @@ jobs:
           username: ${{ secrets.GCP_USERNAME_DEV }}
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY_API_DEV }}
           script: |
-            sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/soongan-api-dev:latest
-            sudo docker stop $(sudo docker ps -q) || true
-            sudo docker rm $(sudo docker ps -a -q) || true
-            sudo docker run -d --name soongan-api-dev -p 8080:8080 \
-              -e INFISICAL_TOKEN=${{ secrets.INFISICAL_TOKEN_API_DEV }} \
-              -e INFISICAL_PROJECT_ID=${{ secrets.INFISICAL_PROJECT_ID_API }} \
-              ${{ secrets.DOCKER_USERNAME }}/soongan-api-dev:latest
+            set -euo pipefail
+
+            APP_NAME="soongan-api-dev"
+            IMAGE="${{ secrets.DOCKER_USERNAME }}/soongan-api-dev:latest"
+            APP_DIR="/opt/soongan"
+            ENV_FILE="$APP_DIR/.env"
+
+            # --- 1) 준비 디렉토리
+            sudo mkdir -p "$APP_DIR"
+            sudo chown "$USER":"$USER" "$APP_DIR"
+
+            # --- 2) Docker 로그인 & 최신 이미지 pull
+            echo "Logging into DockerHub..."
+            sudo docker login -u '${{ secrets.DOCKER_USERNAME }}' -p '${{ secrets.DOCKER_TOKEN }}'
+            echo "Pulling image $IMAGE ..."
+            sudo docker pull "$IMAGE"
+
+            # --- 3) Infisical CLI 설치(신규 리포)
+            if ! command -v infisical >/dev/null 2>&1; then
+              echo "Installing Infisical CLI..."
+              curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+              sudo apt-get install -y infisical
+            fi
+
+            # --- 4) 비밀을 .env로 export (dotenv 형식)
+            echo "Exporting secrets to $ENV_FILE ..."
+            infisical export \
+              --token='${{ secrets.INFISICAL_TOKEN_API_DEV }}' \
+              --projectId='${{ secrets.INFISICAL_PROJECT_ID_API }}' \
+              --env=dev \
+              --format=dotenv \
+              --silent > "$ENV_FILE"
+
+            # 필요시 고정 환경변수 추가
+            {
+              echo "SPRING_PROFILES_ACTIVE=dev"
+              echo "JAVA_TOOL_OPTIONS=-XX:+UseG1GC"
+            } >> "$ENV_FILE"
+
+            # --- 5) 기존 컨테이너만 안전하게 교체
+            if sudo docker ps -a --format '{{.Names}}' | grep -q "^${APP_NAME}$"; then
+              echo "Stopping existing container ${APP_NAME} ..."
+              sudo docker stop "${APP_NAME}" || true
+              sudo docker rm "${APP_NAME}" || true
+            fi
+
+            # --- 6) 새 컨테이너 실행
+            echo "Starting ${APP_NAME} ..."
+            sudo docker run -d --name "${APP_NAME}" \
+              --restart=always \
+              --env-file "$ENV_FILE" \
+              -p 8080:8080 \
+              "$IMAGE"
+
+            # --- 7) 헬스체크(옵션)
+            sleep 3
+            sudo docker ps --filter "name=${APP_NAME}"

--- a/.github/workflows/on-pull-request-api-dev.yml
+++ b/.github/workflows/on-pull-request-api-dev.yml
@@ -24,8 +24,9 @@ jobs:
 
       - name: Install Infisical CLI
         run: |
-          curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | sudo -E bash
-          sudo apt-get update && sudo apt-get install -y infisical
+          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+          sudo apt-get install -y infisical
+          infisical --version
 
       - name: Build with Gradle and Infisical
         run: |
@@ -33,8 +34,8 @@ jobs:
           export INFISICAL_PROJECT_ID=${{ secrets.INFISICAL_PROJECT_ID_API }}
           export SPRING_PROFILES_ACTIVE=local
           infisical run \
-            --token=$INFISICAL_TOKEN \
-            --projectId=$INFISICAL_PROJECT_ID \
+            --token="$INFISICAL_TOKEN" \
+            --projectId="$INFISICAL_PROJECT_ID" \
             --env=local \
             --path=. \
             -- ./gradlew :soongan-api:build

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostResponseDto.kt
@@ -1,5 +1,6 @@
 package com.soongan.soonganbackend.soonganapi.interfaces.weeklyContest.dto.response
 
+import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostEntity
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -31,10 +32,25 @@ data class WeeklyContestPostResponseDto(
 
     @Schema(description = "게시글 댓글 수", type = "Int")
     val commentCount: Int,
+
+    @Schema(description = "해당 게시글이 탑 7에 속하는지 여부. 아직 진행 중인 콘테스트라면 무조건 false", type = "Boolean")
+    val isTop7: Boolean,
+
+    @Schema(description = "콘테스트 회차", type = "Int", nullable = true)
+    val weeklyContestRound: Int,
+
+    @Schema(description = "콘테스트 주제", type = "String", nullable = true)
+    val weeklyContestSubject: String
 ) {
 
     companion object {
-        fun from(memberId: Long? = null, weeklyContestPost: WeeklyContestPostEntity, isLiked: Boolean = false): WeeklyContestPostResponseDto {
+        fun from(
+            memberId: Long? = null,
+            weeklyContestPost: WeeklyContestPostEntity,
+            weeklyContest: WeeklyContestEntity,
+            isLiked: Boolean = false,
+            isTop7: Boolean = false
+        ): WeeklyContestPostResponseDto {
             return WeeklyContestPostResponseDto(
                 memberId = memberId,
                 authorMemberId = weeklyContestPost.member.id,
@@ -44,7 +60,10 @@ data class WeeklyContestPostResponseDto(
                 nickname = weeklyContestPost.member.nickname!!,
                 likeCount = weeklyContestPost.likeCount,
                 isLiked = isLiked,
-                commentCount = weeklyContestPost.commentCount
+                commentCount = weeklyContestPost.commentCount,
+                isTop7 = isTop7,
+                weeklyContestRound = weeklyContest.round,
+                weeklyContestSubject = weeklyContest.subject
             )
         }
     }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostResponseDto.kt
@@ -36,10 +36,10 @@ data class WeeklyContestPostResponseDto(
     @Schema(description = "해당 게시글이 탑 7에 속하는지 여부. 아직 진행 중인 콘테스트라면 무조건 false", type = "Boolean")
     val isTop7: Boolean,
 
-    @Schema(description = "콘테스트 회차", type = "Int", nullable = true)
+    @Schema(description = "콘테스트 회차", type = "Int")
     val weeklyContestRound: Int,
 
-    @Schema(description = "콘테스트 주제", type = "String", nullable = true)
+    @Schema(description = "콘테스트 주제", type = "String")
     val weeklyContestSubject: String
 ) {
 

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/WeeklyContestService.kt
@@ -15,6 +15,7 @@ import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.postLike.PostLikeAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestEntity
+import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal.WeeklyContestFinalAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostEntity
 import com.soongan.soonganbackend.soongansupport.domain.ContestTypeEnum
@@ -32,6 +33,7 @@ import java.time.LocalDateTime
 class WeeklyContestService(
     private val weeklyContestAdapter: WeeklyContestAdapter,
     private val weeklyContestPostAdapter: WeeklyContestPostAdapter,
+    private val weeklyContestFinalAdapter: WeeklyContestFinalAdapter,
     private val gcpStorageService: GcpStorageService,
     private val weeklyContestPostValidator: WeeklyContestPostValidator,
     private val weeklyContestValidator: WeeklyContestValidator,
@@ -48,13 +50,25 @@ class WeeklyContestService(
     fun getWeeklyContestPost(postId: Long, loginMember: MemberEntity?): WeeklyContestPostResponseDto {
         val weeklyContestPost: WeeklyContestPostEntity = weeklyContestPostAdapter.getByIdOrNull(postId)
             ?: throw SoonganException(StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST_POST)
+        val isTop7: Boolean = weeklyContestFinalAdapter.isTop7Post(weeklyContestPost)
 
         loginMember?.let {
             val isLiked: Boolean = likeAdapter.existsByPostIdAndContestTypeAndMember(postId, ContestTypeEnum.WEEKLY, loginMember)
-            return WeeklyContestPostResponseDto.Companion.from(loginMember.id, weeklyContestPost, isLiked)
+            return WeeklyContestPostResponseDto.Companion.from(
+                memberId = loginMember.id,
+                weeklyContestPost = weeklyContestPost,
+                isLiked = isLiked,
+                isTop7 = isTop7,
+                weeklyContest = weeklyContestPost.weeklyContest,
+            )
         }
 
-        return WeeklyContestPostResponseDto.Companion.from(weeklyContestPost =  weeklyContestPost)
+
+        return WeeklyContestPostResponseDto.Companion.from(
+            weeklyContestPost =  weeklyContestPost,
+            isTop7 = isTop7,
+            weeklyContest = weeklyContestPost.weeklyContest,
+        )
     }
 
     @Transactional(readOnly = true)

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalAdapter.kt
@@ -1,5 +1,6 @@
 package com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal
 
+import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostEntity
 import org.springframework.stereotype.Component
 
 @Component
@@ -12,5 +13,9 @@ class WeeklyContestFinalAdapter(
 
     fun getFirstPrizePostByContestId(contestId: Long): WeeklyContestFinalEntity? {
         return weeklyContestFinRepository.findFirstPrizePostByContestId(contestId)
+    }
+
+    fun isTop7Post(post: WeeklyContestPostEntity): Boolean {
+        return weeklyContestFinRepository.existsByWeeklyContestPost(post)
     }
 }

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
@@ -1,5 +1,6 @@
 package com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal
 
+import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -9,4 +10,6 @@ interface WeeklyContestFinalRepository: JpaRepository<WeeklyContestFinalEntity, 
 
     @Query("SELECT wcf FROM WeeklyContestFinalEntity wcf WHERE wcf.weeklyContest.id = :contestId ORDER BY wcf.ranking ASC LIMIT 1")
     fun findFirstPrizePostByContestId(contestId: Long): WeeklyContestFinalEntity?
+
+    fun existsByWeeklyContestPost(weeklyContestPostEntity: WeeklyContestPostEntity): Boolean
 }


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- 게시글 단일 조회 API 응답에 탑7 여부, 회차 정보 포함

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



