### PR TITLE
Add contest status for home response

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/home/dto/response/HomeResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/home/dto/response/HomeResponseDto.kt
@@ -2,6 +2,7 @@ package com.soongan.soonganbackend.soonganapi.interfaces.home.dto.response
 
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.type.WeeklyContestPostAndIsLiked
+import com.soongan.soonganbackend.soongansupport.domain.ContestStatusEnum
 import com.soongan.soonganbackend.soongansupport.domain.ContestTypeEnum
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -20,6 +21,7 @@ data class HomeResponseDto(
         // daily contest response 와 분리하기 위한 네이밍
         fun fromWeeklyContest(
             weeklyContest: WeeklyContestEntity,
+            status: ContestStatusEnum,
             postInfo: List<WeeklyContestPostAndIsLiked>
         ): HomeResponseDto {
             return HomeResponseDto(
@@ -27,7 +29,8 @@ data class HomeResponseDto(
                     contestType = ContestTypeEnum.WEEKLY,
                     subject = weeklyContest.subject,
                     startAt = weeklyContest.startAt,
-                    endAt = weeklyContest.endAt
+                    endAt = weeklyContest.endAt,
+                    status = status
                 ),
                 postInfo = postInfo.map {
                     HomeMyPostInfo(
@@ -47,6 +50,8 @@ data class HomeResponseDto(
         val subject: String,
         val startAt: LocalDateTime,
         val endAt: LocalDateTime,
+        @Schema(description = "콘테스트 상태", example = "UPCOMING, IN_PROGRESS, CLOSED")
+        val status: ContestStatusEnum
     )
 
     data class HomeMyPostInfo(

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/home/HomeService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/home/HomeService.kt
@@ -3,7 +3,6 @@ package com.soongan.soonganbackend.soonganapi.service.home
 import com.soongan.soonganbackend.soonganapi.interfaces.home.dto.response.HomeResponseDto
 import com.soongan.soonganbackend.soonganapi.service.weeklyContest.validator.WeeklyContestValidator
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
-import com.soongan.soonganbackend.soonganpersistence.storage.postLike.PostLikeAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.type.WeeklyContestPostAndIsLiked
@@ -28,6 +27,12 @@ class HomeService(
                 weeklyContest
             )
 
-        return HomeResponseDto.fromWeeklyContest(weeklyContest, homeWeeklyContestPostList)
+        val contestStatus = weeklyContestValidator.determineContestStatus(weeklyContest)
+
+        return HomeResponseDto.fromWeeklyContest(
+            weeklyContest = weeklyContest,
+            status = contestStatus,
+            postInfo = homeWeeklyContestPostList
+        )
     }
 }

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/home/HomeService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/home/HomeService.kt
@@ -16,9 +16,10 @@ class HomeService(
 
     fun getHome(loginMember: MemberEntity?): HomeResponseDto {
         val weeklyContest: WeeklyContestEntity = weeklyContestValidator.getWeeklyContestIfValidRound()
+        val contestStatus = weeklyContestValidator.determineContestStatus(weeklyContest)
 
         if (loginMember == null) {
-            return HomeResponseDto.fromWeeklyContest(weeklyContest, emptyList())
+            return HomeResponseDto.fromWeeklyContest(weeklyContest, contestStatus, emptyList())
         }
 
         val homeWeeklyContestPostList: List<WeeklyContestPostAndIsLiked> =
@@ -26,8 +27,6 @@ class HomeService(
                 loginMember,
                 weeklyContest
             )
-
-        val contestStatus = weeklyContestValidator.determineContestStatus(weeklyContest)
 
         return HomeResponseDto.fromWeeklyContest(
             weeklyContest = weeklyContest,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/validator/WeeklyContestValidator.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/validator/WeeklyContestValidator.kt
@@ -3,6 +3,7 @@ package com.soongan.soonganbackend.soonganapi.service.weeklyContest.validator
 import com.soongan.soonganbackend.soonganapi.admin.weeklyContest.dto.request.UpdateWeeklyContestAdminRequestDto
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestEntity
+import com.soongan.soonganbackend.soongansupport.domain.ContestStatusEnum
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
 import com.soongan.soonganbackend.soongansupport.util.exception.StatusCode
 import org.springframework.stereotype.Component
@@ -62,6 +63,16 @@ class WeeklyContestValidator(
             (requestDto.endAt != null && requestDto.endAt < now)
         ) {
             throw SoonganException(statusCode = StatusCode.BAD_REQUEST, "수정할 콘테스트 시간은 현재 시간 이후여야 합니다.")
+        }
+    }
+
+    fun determineContestStatus(weeklyContest: WeeklyContestEntity): ContestStatusEnum {
+        val now = LocalDateTime.now()
+
+        return when {
+            now.isBefore(weeklyContest.startAt) -> ContestStatusEnum.UPCOMING
+            now.isAfter(weeklyContest.endAt) -> ContestStatusEnum.CLOSED
+            else -> ContestStatusEnum.IN_PROGRESS
         }
     }
 }

--- a/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/home/HomeServiceTest.kt
+++ b/apps/soongan-api/src/test/kotlin/com/soongan/soonganbackend/soonganapi/unit/service/home/HomeServiceTest.kt
@@ -8,6 +8,7 @@ import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.Weekl
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.type.WeeklyContestPostAndIsLiked
+import com.soongan.soonganbackend.soongansupport.domain.ContestStatusEnum
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
@@ -66,6 +67,7 @@ class HomeServiceTest {
 
         // mock
         every { weeklyContestValidator.getWeeklyContestIfValidRound() } returns weeklyContest
+        every { weeklyContestValidator.determineContestStatus(weeklyContest) } returns ContestStatusEnum.IN_PROGRESS
         every { weeklyContestPostAdapter.getHomePostsWithIsLiked(loginMember, weeklyContest) } returns homeWeeklyContestPostList
 
         // when

--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/domain/ContestStatusEnum.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/domain/ContestStatusEnum.kt
@@ -1,0 +1,8 @@
+package com.soongan.soonganbackend.soongansupport.domain
+
+enum class ContestStatusEnum {
+    UPCOMING,
+    IN_PROGRESS,
+    CLOSED
+    ;
+}


### PR DESCRIPTION
# 관련이슈

# Base on Branch

- develop

# 변경점

- Home API 응답에 현재 노출된 contest 상태 응답

# Example/Screenshot (if any)

- 

# TODO

- [ ] local test     



