### PR TITLE
  feat: 신고 3회 이상 게시물 상세 접근 차단 기능 추가

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/WeeklyContestService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/weeklyContest/WeeklyContestService.kt
@@ -13,12 +13,14 @@ import com.soongan.soonganbackend.soonganapi.service.weeklyContest.validator.Wee
 import com.soongan.soonganbackend.soonganapi.service.weeklyContestPost.validator.WeeklyContestPostValidator
 import com.soongan.soonganbackend.soonganpersistence.storage.member.MemberEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.postLike.PostLikeAdapter
+import com.soongan.soonganbackend.soonganpersistence.storage.report.ReportAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContest.WeeklyContestEntity
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestFinal.WeeklyContestFinalAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostAdapter
 import com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.WeeklyContestPostEntity
 import com.soongan.soonganbackend.soongansupport.domain.ContestTypeEnum
+import com.soongan.soonganbackend.soongansupport.domain.ReportTargetTypeEnum
 import com.soongan.soonganbackend.soongansupport.domain.WeeklyContestPostOrderCriteriaEnum
 import com.soongan.soonganbackend.soongansupport.service.GcpStorageService
 import com.soongan.soonganbackend.soongansupport.util.exception.SoonganException
@@ -37,7 +39,8 @@ class WeeklyContestService(
     private val gcpStorageService: GcpStorageService,
     private val weeklyContestPostValidator: WeeklyContestPostValidator,
     private val weeklyContestValidator: WeeklyContestValidator,
-    private val likeAdapter: PostLikeAdapter
+    private val likeAdapter: PostLikeAdapter,
+    private val reportAdapter: ReportAdapter
 ) {
 
     @Transactional(readOnly = true)
@@ -50,6 +53,13 @@ class WeeklyContestService(
     fun getWeeklyContestPost(postId: Long, loginMember: MemberEntity?): WeeklyContestPostResponseDto {
         val weeklyContestPost: WeeklyContestPostEntity = weeklyContestPostAdapter.getByIdOrNull(postId)
             ?: throw SoonganException(StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST_POST)
+
+        // 신고 3회 이상 게시물 접근 차단
+        val reportCount = reportAdapter.countByTargetIdAndTargetType(postId, ReportTargetTypeEnum.WEEKLY_POST)
+        if (reportCount >= 3) {
+            throw SoonganException(StatusCode.SOONGAN_API_POST_ACCESS_RESTRICTED_BY_REPORTS)
+        }
+
         val isTop7: Boolean = weeklyContestFinalAdapter.isTop7Post(weeklyContestPost)
 
         loginMember?.let {

--- a/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/exception/StatusCode.kt
+++ b/libs/soongan-support/src/main/kotlin/com/soongan/soonganbackend/soongansupport/util/exception/StatusCode.kt
@@ -43,6 +43,7 @@ enum class StatusCode(val code: Int, val message: String) {
     SOONGAN_API_WEEKLY_CONTEST_POST_REGISTER_LIMIT_EXCEEDED(1103, "Weekly Contest Post Register Limit Exceeded"),
     SOONGAN_API_NOT_OWNER_WEEKLY_CONTEST_POST(1104, "Not Owner Weekly Contest Post"),
     SOONGAN_API_CANNOT_UPDATE_POST_AFTER_VOTE_END(1105, "Cannot Update Post After End Vote"),
+    SOONGAN_API_POST_ACCESS_RESTRICTED_BY_REPORTS(1106, "Post Access Restricted By Reports"),
 
     // 1200 ~ 1299 Like Status Code
     SOONGAN_API_DUPLICATED_LIKE(1200, "Duplicated Like"),


### PR DESCRIPTION
feat: 신고 3회 이상 게시물 상세 접근 차단 기능 추가

- 게시물 상세 조회 시 신고 횟수 검증 로직 추가
- 신고 3회 이상 시 접근 차단 예외 발생
- StatusCode에 POST_ACCESS_RESTRICTED_BY_REPORTS(1106) 추가
