### PR TITLE
feat: 역대 콘테스트 목록에서 Final 없어도 실시간 1등 계산

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/awards/AwardsService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/awards/AwardsService.kt
@@ -22,16 +22,18 @@ class AwardsService(
     fun getWeeklyContestAwards(): WeeklyContestAwardsResponseDto {
         // 1차 투표가 끝난 주간 콘테스트들만 조회
         val weeklyContestList: List<WeeklyContestEntity> = weeklyContestAdapter.getEndedWeeklyContests()
-        return weeklyContestList.map { contest ->
-            val firstPrizePost = weeklyContestFinalAdapter.getFirstPrizePostByContestId(contest.id)
-                ?: throw SoonganException(
-                    StatusCode.SOONGAN_API_NOT_FOUND_WEEKLY_CONTEST_POST,
-                    "해당 콘테스트의 1등 게시글이 존재하지 않습니다. contestId: ${contest.id}"
-                )
+        return weeklyContestList.mapNotNull { contest ->
+            // 1. Final에서 확정된 1등 조회
+            val finalFirstPost = weeklyContestFinalAdapter.getFirstPrizePostByContestId(contest.id)
+
+            // 2. Final이 없으면 WeeklyContestPost에서 실시간 1등 계산
+            val firstPlaceImageUrl = finalFirstPost?.weeklyContestPost?.imageUrl
+                ?: weeklyContestPostAdapter.getFirstPlacePost(contest)?.imageUrl
+                ?: return@mapNotNull null // 게시물이 하나도 없으면 목록에서 제외
 
             WeeklyContestAwardsResponseDto.WeeklyContestDto.from(
                 entity = contest,
-                thumbnailImageUrl = firstPrizePost.weeklyContestPost.imageUrl
+                thumbnailImageUrl = firstPlaceImageUrl
             )
         }.let { WeeklyContestAwardsResponseDto(it) }
     }

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
@@ -37,6 +37,11 @@ class WeeklyContestPostAdapter(
     }
 
     @Transactional(readOnly = true)
+    fun getFirstPlacePost(weeklyContest: WeeklyContestEntity): WeeklyContestPostEntity? {
+        return weeklyContestPostRepository.findFirstPlacePost(weeklyContest)
+    }
+
+    @Transactional(readOnly = true)
     fun getLatestPostWithSlicing(
         weeklyContest: WeeklyContestEntity,
         page: Int,

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
@@ -49,6 +49,24 @@ interface WeeklyContestPostRepository : JpaRepository<WeeklyContestPostEntity, L
 
     fun countByWeeklyContestId(weeklyContestId: Long): Int
 
+    // 해당 콘테스트의 1등 게시물 조회 (좋아요 많은 순, 동점 시 업로드 시간 빠른 순)
+    @Query("""
+        SELECT p
+        FROM WeeklyContestPostEntity p
+        WHERE p.weeklyContest = :weeklyContest
+            AND p.deletedAt IS NULL
+            AND p.blindedAt IS NULL
+            AND (
+                SELECT COUNT(r)
+                FROM ReportEntity r
+                WHERE r.targetId = p.id
+                    AND r.targetType = 'WEEKLY_POST'
+            ) < 3
+        ORDER BY p.likeCount DESC, p.createdAt ASC
+        LIMIT 1
+    """)
+    fun findFirstPlacePost(@Param("weeklyContest") weeklyContest: WeeklyContestEntity): WeeklyContestPostEntity?
+
     // `JOIN`을 통해 게시물과 좋아요 여부를 함께 가져오는 쿼리
     @Query("""
         SELECT new com.soongan.soonganbackend.soonganpersistence.storage.weeklyContestPost.type.WeeklyContestPostAndIsLiked(


### PR DESCRIPTION
  - WeeklyContestPostRepository에 findFirstPlacePost 쿼리 추가
  - 정렬 기준: 좋아요 많은 순 → 업로드 시간 빠른 순 (동점자 처리)
  - AwardsService에 2단계 폴백 로직 구현 1단계: Final 테이블에서 확정된 1등 조회 2단계: Final 없으면 실시간 계산
  - 신고 3회 이상, 삭제/블라인드 게시물 제외
  - .dockerignore README.md 제외 해제

  기존에는 Final 데이터가 없으면 에러가 발생했으나,
  이제는 실시간으로 좋아요 순위를 계산하여 표시합니다.

https://captures2024.atlassian.net/browse/SG-191


