### PR TITLE
feat: awards 및 my-history 목록 내림차순 정렬 추가

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/app/AppService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/app/AppService.kt
@@ -16,11 +16,11 @@ class AppService {
     companion object {
         // 최신 버전 정의 (플랫폼별)
         private const val LATEST_VERSION_ANDROID = "2.0.1"
-        private const val LATEST_VERSION_IOS = "2.0.1"
+        private const val LATEST_VERSION_IOS = "1.0.0"
 
         // 강제 업데이트가 필요한 최소 버전 (이 버전보다 낮으면 강제 업데이트)
         private const val MIN_VERSION_ANDROID = "2.0.0"
-        private const val MIN_VERSION_IOS = "2.0.0"
+        private const val MIN_VERSION_IOS = "1.0.0"
     }
 
     fun checkVersion(versionCheckRequestDto: VersionCheckRequestDto): VersionCheckResponseDto {

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContest/WeeklyContestRepository.kt
@@ -10,7 +10,7 @@ interface WeeklyContestRepository: JpaRepository<WeeklyContestEntity, Long> {
 
     fun findByRound(round: Int): WeeklyContestEntity?
 
-    @Query("SELECT wc FROM WeeklyContestEntity wc WHERE wc.endAt <= :now")
+    @Query("SELECT wc FROM WeeklyContestEntity wc WHERE wc.endAt <= :now ORDER BY wc.createdAt DESC")
     fun findEndedContests(now: LocalDateTime): List<WeeklyContestEntity>
 
     @Query("SELECT wc FROM WeeklyContestEntity wc WHERE wc.startAt <= :now AND wc.endAt > :now")

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
@@ -94,7 +94,7 @@ class WeeklyContestPostAdapter(
         page: Int,
         size: Int
     ): Page<WeeklyContestPostEntity> {
-        return weeklyContestPostRepository.findAllByMember(
+        return weeklyContestPostRepository.findAllByMemberOrderByCreatedAtDesc(
             member,
             PageRequest.of(page, size)
         )

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
@@ -73,7 +73,7 @@ interface WeeklyContestPostRepository : JpaRepository<WeeklyContestPostEntity, L
         member: MemberEntity
     ): Int
 
-    fun findAllByMember(
+    fun findAllByMemberOrderByCreatedAtDesc(
         member: MemberEntity,
         pageable: Pageable
     ): Page<WeeklyContestPostEntity>


### PR DESCRIPTION
  - awards 목록을 최신 라운드부터 표시하도록 변경
  - my-history 목록을 최신 게시물부터 표시하도록 변경
  - WeeklyContestRepository.findEndedContests에 ORDER BY round DESC 추가
  - WeeklyContestPostRepository.findAllByMember를 OrderByCreatedAtDesc로 변경
2.0.1 -> 1.0.0

https://captures2024.atlassian.net/browse/SG-201
https://captures2024.atlassian.net/browse/SG-202

