### PR TITLE
feat: FCM 토큰을 선택사항으로 변경

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/auth/dto/request/LoginRequestDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/auth/dto/request/LoginRequestDto.kt
@@ -15,7 +15,6 @@ data class LoginRequestDto(
     @field:NotBlank(message = "iDToken 정보는 필수입니다.")
     val idToken: String,
 
-    @Schema(description = "해당 기기 FCM Token", required = true)
-    @field:NotBlank(message = "fcmToken 정보는 필수입니다.")
-    val fcmToken: String
+    @Schema(description = "해당 기기 FCM Token", required = false)
+    val fcmToken: String? = null
 )

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/service/auth/AuthService.kt
@@ -86,13 +86,14 @@ class AuthService(
             logger.info { "[Auth] register user=${member.id}, provider=${member.provider}, ip=$clientIp" }
         }
 
-        fcmTokenAdapter.findByToken(loginDto.fcmToken)?.let { foundFcmToken ->
-            if (foundFcmToken.member == null || foundFcmToken.member!!.id != member.id) {
-                fcmTokenAdapter.save(foundFcmToken.copy(id = foundFcmToken.id, member = member))
+        loginDto.fcmToken?.let { fcmToken ->
+            fcmTokenAdapter.findByToken(fcmToken)?.let { foundFcmToken ->
+                if (foundFcmToken.member == null || foundFcmToken.member!!.id != member.id) {
+                    fcmTokenAdapter.save(foundFcmToken.copy(id = foundFcmToken.id, member = member))
+                }
+            } ?: run {
+                logger.warn { "[Auth] login_warning user=${member.id}, provider=$provider, ip=$clientIp, reason=FCM token not found in DB" }
             }
-        } ?: run {
-            logger.warn { "[Auth] login_failed user=${member.id}, provider=$provider, ip=$clientIp, reason=FCM token not found" }
-            throw SoonganException(StatusCode.SOONGAN_API_NOT_FOUND_FCM_TOKEN)
         }
 
         val issuedTokens = jwtHandler.issueTokens(member.email)


### PR DESCRIPTION
- LoginRequestDto의 fcmToken을 nullable로 변경
- FCM 토큰 없이도 로그인 가능하도록 개선
- FCM 토큰이 DB에 없어도 로그인 실패하지 않고 warning만 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)
