### PR TITLE
fix: 주간 콘테스트 게시물 목록 조회 시 member null NPE 수정

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostListResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostListResponseDto.kt
@@ -51,10 +51,12 @@ data class WeeklyContestPostListResponseDto(
             return WeeklyContestPostListResponseDto(
                 round = weeklyContest.round,
                 subject = weeklyContest.subject,
-                posts = postSlice.content.map {
+                posts = postSlice.content.mapNotNull {
+                    // member가 null이면 해당 게시물을 제외
+                    val member = it.member ?: return@mapNotNull null
                     WeeklyContestPostDto(
-                        nickname = it.member.nickname!!,
-                        profileImageUrl = it.member.profileImageUrl ?: DEFAULT_PROFILE_IMAGE_URL,
+                        nickname = member.nickname ?: "알 수 없음",
+                        profileImageUrl = member.profileImageUrl ?: DEFAULT_PROFILE_IMAGE_URL,
                         postId = it.id,
                         imageUrl = it.imageUrl,
                         ratio = it.ratio,

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
@@ -145,6 +145,7 @@ class WeeklyContestPostAdapter(
 
         val query: JPAQuery<WeeklyContestPostEntity> = queryFactory
             .selectFrom(weeklyContestPostEntity)
+            .join(weeklyContestPostEntity.member).fetchJoin()
             .where(
                 weeklyContestPostEntity.weeklyContest.eq(weeklyContest),
                 reportCountSubquery.lt(3L)
@@ -186,6 +187,7 @@ class WeeklyContestPostAdapter(
 
         val query: JPAQuery<WeeklyContestPostEntity> = queryFactory
             .selectFrom(weeklyContestPostEntity)
+            .join(weeklyContestPostEntity.member).fetchJoin()
             .where(
                 weeklyContestPostEntity.weeklyContest.eq(weeklyContest),
                 reportCountSubquery.lt(3L)
@@ -226,6 +228,7 @@ class WeeklyContestPostAdapter(
 
         val query: JPAQuery<WeeklyContestPostEntity> = queryFactory
             .selectFrom(weeklyContestPostEntity)
+            .join(weeklyContestPostEntity.member).fetchJoin()
             .where(
                 weeklyContestPostEntity.weeklyContest.eq(weeklyContest),
                 reportCountSubquery.lt(3L)

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostRepository.kt
@@ -17,6 +17,7 @@ interface WeeklyContestPostRepository : JpaRepository<WeeklyContestPostEntity, L
     @Query("""
         SELECT p
         FROM WeeklyContestPostEntity p
+        JOIN FETCH p.member
         WHERE p.weeklyContest = :weeklyContestEntity
             AND (
                 SELECT COUNT(r)
@@ -35,6 +36,7 @@ interface WeeklyContestPostRepository : JpaRepository<WeeklyContestPostEntity, L
     @Query("""
         SELECT p
         FROM WeeklyContestPostEntity p
+        JOIN FETCH p.member
         WHERE p.weeklyContest = :weeklyContestEntity
             AND (
                 SELECT COUNT(r)
@@ -53,6 +55,7 @@ interface WeeklyContestPostRepository : JpaRepository<WeeklyContestPostEntity, L
     @Query("""
         SELECT p
         FROM WeeklyContestPostEntity p
+        JOIN FETCH p.member
         WHERE p.weeklyContest = :weeklyContestEntity
             AND (
                 SELECT COUNT(r)


### PR DESCRIPTION
- Repository 쿼리에 JOIN FETCH p.member 추가로 member 즉시 로딩
- QueryDSL 쿼리에 fetchJoin() 추가
- DTO에서 mapNotNull 사용하여 member null인 경우 안전하게 필터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)
