### PR TITLE
fix: Awards 및 기타 API에서 member null NPE 수정

### DIFF
--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/awards/dto/response/AwardsDetailResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/awards/dto/response/AwardsDetailResponseDto.kt
@@ -41,18 +41,19 @@ data class AwardsDetailResponseDto(
     ) {
         companion object {
             fun from(weeklyContestFinalEntity: WeeklyContestFinalEntity): FirstPrizePostResponseDto {
+                val post = weeklyContestFinalEntity.weeklyContestPost
                 return FirstPrizePostResponseDto(
-                    postId = weeklyContestFinalEntity.weeklyContestPost.id,
-                    title = weeklyContestFinalEntity.weeklyContestPost.title,
-                    imageUrl = weeklyContestFinalEntity.weeklyContestPost.imageUrl,
-                    nickname = weeklyContestFinalEntity.weeklyContestPost.member.nickname,
+                    postId = post.id,
+                    title = post.title,
+                    imageUrl = post.imageUrl,
+                    nickname = post.member?.nickname ?: "알 수 없음",
                     score = weeklyContestFinalEntity.score,
-                    status = if (weeklyContestFinalEntity.weeklyContestPost.deletedAt != null) {
-                        when (weeklyContestFinalEntity.weeklyContestPost.deletedReason) {
+                    status = if (post.deletedAt != null) {
+                        when (post.deletedReason) {
                             DeletedReasonEnum.BY_CREATOR -> AwardsPostStatusEnum.DELETED_BY_CREATOR
                             else -> AwardsPostStatusEnum.DELETED_BY_ADMIN // deletedAt이 true인데 deletedReason이 null인 경우는 어쩌지? 일단 admin 삭제로 처리
                         }
-                    } else if (weeklyContestFinalEntity.weeklyContestPost.blindedAt != null) {
+                    } else if (post.blindedAt != null) {
                         AwardsPostStatusEnum.BLINDED
                     } else {
                         AwardsPostStatusEnum.ACTIVE
@@ -87,9 +88,9 @@ data class AwardsDetailResponseDto(
                 }
 
                 return TopPostResponseDto(
-                    postId = weeklyContestFinalEntity.weeklyContestPost.id,
+                    postId = post.id,
                     imageUrl = post.imageUrl,
-                    nickname = post.member.nickname,
+                    nickname = post.member?.nickname ?: "알 수 없음",
                     ranking = weeklyContestFinalEntity.ranking,
                     score = weeklyContestFinalEntity.score,
                     status = status

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostListCursorResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostListCursorResponseDto.kt
@@ -49,10 +49,11 @@ data class WeeklyContestPostListCursorResponseDto(
             return WeeklyContestPostListCursorResponseDto(
                 round = weeklyContest.round,
                 subject = weeklyContest.subject,
-                posts = posts.data?.map {
+                posts = posts.data?.mapNotNull {
+                    val member = it.member ?: return@mapNotNull null
                     WeeklyContestPostDto(
-                        nickname = it.member.nickname!!,
-                        profileImageUrl = it.member.profileImageUrl ?: DEFAULT_PROFILE_IMAGE_URL,
+                        nickname = member.nickname ?: "알 수 없음",
+                        profileImageUrl = member.profileImageUrl ?: DEFAULT_PROFILE_IMAGE_URL,
                         postId = it.id,
                         likeCount = it.likeCount,
                         imageUrl = it.imageUrl,

--- a/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostResponseDto.kt
+++ b/apps/soongan-api/src/main/kotlin/com/soongan/soonganbackend/soonganapi/interfaces/weeklyContest/dto/response/WeeklyContestPostResponseDto.kt
@@ -57,14 +57,15 @@ data class WeeklyContestPostResponseDto(
             isLiked: Boolean = false,
             isTop7: Boolean = false
         ): WeeklyContestPostResponseDto {
+            val member = weeklyContestPost.member
             return WeeklyContestPostResponseDto(
                 memberId = memberId,
-                authorMemberId = weeklyContestPost.member.id,
+                authorMemberId = member?.id ?: 0L,
                 postId = weeklyContestPost.id,
                 title = weeklyContestPost.title,
                 imageUrl = weeklyContestPost.imageUrl,
                 ratio = weeklyContestPost.ratio,
-                nickname = weeklyContestPost.member.nickname!!,
+                nickname = member?.nickname ?: "알 수 없음",
                 likeCount = weeklyContestPost.likeCount,
                 isLiked = isLiked,
                 commentCount = weeklyContestPost.commentCount,

--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestFinal/WeeklyContestFinalRepository.kt
@@ -6,9 +6,24 @@ import org.springframework.data.jpa.repository.Query
 
 interface WeeklyContestFinalRepository: JpaRepository<WeeklyContestFinalEntity, Long> {
 
+    @Query("""
+        SELECT wcf
+        FROM WeeklyContestFinalEntity wcf
+        JOIN FETCH wcf.weeklyContestPost post
+        JOIN FETCH post.member
+        WHERE wcf.weeklyContest.id = :contestId
+    """)
     fun findAllByWeeklyContestId(contestId: Long): List<WeeklyContestFinalEntity>
 
-    @Query("SELECT wcf FROM WeeklyContestFinalEntity wcf WHERE wcf.weeklyContest.id = :contestId ORDER BY wcf.ranking ASC LIMIT 1")
+    @Query("""
+        SELECT wcf
+        FROM WeeklyContestFinalEntity wcf
+        JOIN FETCH wcf.weeklyContestPost post
+        JOIN FETCH post.member
+        WHERE wcf.weeklyContest.id = :contestId
+        ORDER BY wcf.ranking ASC
+        LIMIT 1
+    """)
     fun findFirstPrizePostByContestId(contestId: Long): WeeklyContestFinalEntity?
 
     fun existsByWeeklyContestPost(weeklyContestPostEntity: WeeklyContestPostEntity): Boolean


### PR DESCRIPTION
- WeeklyContestFinalRepository에 JOIN FETCH 추가
- AwardsDetailResponseDto에서 member null-safe 처리
- WeeklyContestPostResponseDto에서 member null-safe 처리
- WeeklyContestPostListCursorResponseDto에서 mapNotNull 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

