### PR TITLE
fix: 삭제/블라인드 게시물이 업로드 제한 카운트에 포함되던 문제 수정

### DIFF
--- a/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
+++ b/libs/soongan-persistence/src/main/kotlin/com/soongan/soonganbackend/soonganpersistence/storage/weeklyContestPost/WeeklyContestPostAdapter.kt
@@ -85,7 +85,16 @@ class WeeklyContestPostAdapter(
         weeklyContest: WeeklyContestEntity,
         member: MemberEntity,
     ): Int {
-        return weeklyContestPostRepository.countByWeeklyContestAndMember(weeklyContest, member)
+        return queryFactory
+            .select(weeklyContestPostEntity.count())
+            .from(weeklyContestPostEntity)
+            .where(
+                weeklyContestPostEntity.weeklyContest.eq(weeklyContest),
+                weeklyContestPostEntity.member.eq(member),
+                weeklyContestPostEntity.deletedAt.isNull,
+                weeklyContestPostEntity.blindedAt.isNull
+            )
+            .fetchOne()?.toInt() ?: 0
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
countRegisteredPostByMember 메서드에 deletedAt, blindedAt 필터를 추가하여 삭제된 게시물과 블라인드 처리된 게시물을 업로드 제한 카운트에서 제외하도록 수정